### PR TITLE
add pkg.module and make pkg.main extension-agnostic

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@ampproject/worker-dom",
   "version": "0.1.0",
   "description": "A facsimile of a modern DOM implementation intended to run in a Web Worker.",
-  "main": "dist/index.js",
+  "main": "dist/index",
+  "module": "dist/index.mjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/ampproject/worker-dom.git"


### PR DESCRIPTION
Hi! This is just a small change that makes it easier to import worker-dom in a project using Rollup — the rollup-plugin-node-resolve plugin first looks for the `"module"` field in package.json, and only then falls back to `"main"`.

It also removes the extension from `"main"`, per the current Node recommendation, so that all bases are covered.

Thanks for this extraordinary project!