### PR TITLE
Add subheadings to demo page to stratify out different demo types

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -8,12 +8,22 @@
 </head>
 <body>
   <h1>WorkerDOM Demos</h1>
+
+  <h3>Basic</h3>
   <ul>
-    <li><a href='debugger.html'>Debugger</a></li>
     <li><a href='hello-world.html'>Hello World</a></li>
-    <li><a href='svg.html'>SVG</a></li>
     <li><a href='vanilla.html'>Vanilla</a></li>
-    <li><a href='dbmon.html'>DBMon</a></li>
+    <li><a href='svg.html'>SVG</a></li>
+  </ul>
+  
+  <h3>In Depth</h3>
+  <ul>
+      <li><a href='debugger.html'>Debugger</a></li>
+      <li><a href='dbmon.html'>DBMon</a></li>
+  </ul>
+  
+  <h3>Frameworks</h3>
+  <ul>
     <li><a href='map-preact.html'>Interactive Map Preact</a></li>
     <li><a href='map-react.html'>Interactive Map React</a></li>
     <li><a href='preact-todomvc.html'>Todo MVC Preact</a></li>


### PR DESCRIPTION
This PR stratifies out the demos into sub categories making it easier for developers to find what they are looking for.

![screenshot_20180827_183533](https://user-images.githubusercontent.com/8822075/44675287-fd9a6280-aa27-11e8-83f5-51c5ae60e148.png)
