### PR TITLE
[WIP] Support Building on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+os: 
+  - osx
+  - windows
+  - linux
 language: node_js
 sudo: required
-dist: trusty
 node_js:
   - "lts/*"
 before_install:

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "pre~rollup": "rimraf output dist && tsc -p config/tsconfig.build.worker-thread.json & tsc -p config/tsconfig.build.main-thread.json",
     "~rollup": "rollup --config config/rollup.config.js",
     "lint": "tslint -c config/tslint.json -p src/worker-thread/ & tslint -c config/tslint.json -p src/main-thread/",
-    "predebug": "DEBUG_BUNDLE=true npm run ~rollup",
+    "predebug": "cross-env DEBUG_BUNDLE=true npm run ~rollup",
     "debug": "node -r esm demo/server.mjs",
-    "build": "MINIFY_BUNDLE=true npm run ~rollup",
+    "build": "cross-env MINIFY_BUNDLE=true npm run ~rollup",
     "size": "npm run build && bundlesize"
   },
   "dependencies": {
@@ -39,6 +39,7 @@
     "babel-plugin-minify-replace": "0.4.3",
     "babel-plugin-transform-remove-console": "6.9.4",
     "bundlesize": "0.17.0",
+    "cross-env": "5.2.0",
     "esm": "3.0.76",
     "husky": "1.0.0-rc.13",
     "lint-staged": "7.2.2",


### PR DESCRIPTION
Fix for #3.

Leverage [cross-env](https://github.com/kentcdodds/cross-env) to set environment variables.

Also, travis has been enabled... this PR attempts to ensure its running on `os x`, `windows`, and `linux`. 