### PR TITLE
fix: change `npm run debug` to `npm run demo`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "~rollup": "rollup --config config/rollup.config.js",
     "lint": "tslint -c config/tslint.json -p src/worker-thread/ & tslint -c config/tslint.json -p src/main-thread/",
     "predebug": "cross-env DEBUG_BUNDLE=true npm run ~rollup",
-    "debug": "node -r esm demo/server.mjs",
+    "demo": "node -r esm demo/server.mjs",
     "build": "cross-env MINIFY_BUNDLE=true npm run ~rollup",
     "size": "npm run build && bundlesize"
   },


### PR DESCRIPTION
According to the readme description, you need to provide the `npm run demo` instead of `npm run debug`.