### PR TITLE
Update Polka to 0.5.0

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <title>WorkerDOM Demos</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="google" value="notranslate">
   <link href="demo.css" rel="stylesheet">
 </head>
 <body>

--- a/demo/server.mjs
+++ b/demo/server.mjs
@@ -26,7 +26,6 @@ polka()
   .get('/health', (req, res) => {
     res.end('OK');
   })
-  .listen(PORT)
-  .then(_ => {
+  .listen(PORT, _ => {
     console.log(`> Running on http://localhost:${PORT}`);
   });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "husky": "1.0.0-rc.15",
     "lint-staged": "7.3.0",
     "magic-string": "0.25.1",
-    "polka": "0.4.0",
+    "polka": "0.5.0",
     "prettier": "1.14.3",
     "rimraf": "2.6.2",
     "rollup": "0.66.2",


### PR DESCRIPTION
Polka `0.5.0` had a minor API change that made the demo fallover.

This PR moves the demo to the newer API.