### PR TITLE
Add unminified builds

### DIFF
--- a/config/rollup.main-thread.js
+++ b/config/rollup.main-thread.js
@@ -36,6 +36,20 @@ const ESModules = [
     ].filter(Boolean)
   },
   {
+    input: 'output/main-thread/index.js',
+    output: {
+      file: 'dist/unminified.index.mjs',
+      format: 'es',
+      sourcemap: true,
+    },
+    plugins: [
+      babelPlugin({
+        transpileToES5: false,
+        allowConsole: DEBUG_BUNDLE_VALUE,
+      }),
+    ].filter(Boolean)
+  },
+  {
     input: 'output/main-thread/index.safe.js',
     output: {
       file: 'dist/index.safe.mjs',
@@ -50,7 +64,22 @@ const ESModules = [
       }),
       MINIFY_BUNDLE_VALUE ? compiler() : null,
     ].filter(Boolean)
-  }
+  },
+  {
+    input: 'output/main-thread/index.safe.js',
+    output: {
+      file: 'dist/unminified.index.safe.mjs',
+      format: 'es',
+      sourcemap: true,
+    },
+    plugins: [
+      resolve(),
+      babelPlugin({
+        transpileToES5: false,
+        allowConsole: DEBUG_BUNDLE_VALUE,
+      }),
+    ].filter(Boolean)
+  },
 ];
 
 const IIFEModules = [
@@ -71,6 +100,21 @@ const IIFEModules = [
     ].filter(Boolean)
   },
   {
+    input: 'output/main-thread/index.js',
+    output: {
+      file: 'dist/unminified.index.js',
+      format: 'iife',
+      name: 'MainThread',
+      sourcemap: true,
+    },
+    plugins: [
+      babelPlugin({
+        transpileToES5: true,
+        allowConsole: DEBUG_BUNDLE_VALUE,
+      }),
+    ].filter(Boolean)
+  },
+  {
     input: 'output/main-thread/index.safe.js',
     output: {
       file: 'dist/index.safe.js',
@@ -85,6 +129,22 @@ const IIFEModules = [
         allowConsole: DEBUG_BUNDLE_VALUE,
       }),
       MINIFY_BUNDLE_VALUE ? compiler() : null,
+    ].filter(Boolean)
+  },
+  {
+    input: 'output/main-thread/index.safe.js',
+    output: {
+      file: 'dist/unminified.index.safe.js',
+      format: 'iife',
+      name: 'MainThread',
+      sourcemap: true,
+    },
+    plugins: [
+      resolve(),
+      babelPlugin({
+        transpileToES5: true,
+        allowConsole: DEBUG_BUNDLE_VALUE,
+      }),
     ].filter(Boolean)
   }
 ];

--- a/config/rollup.worker-thread.js
+++ b/config/rollup.worker-thread.js
@@ -42,6 +42,22 @@ const ESModules = [
     ].filter(Boolean)
   },
   {
+    input: 'output/worker-thread/index.js',
+    output: {
+      file: 'dist/unminified.worker.mjs',
+      format: 'iife',
+      name: 'WorkerThread',
+      sourcemap: true,
+    },
+    plugins: [
+      removeTestingDocument(),
+      babelPlugin({
+        transpileToES5: false,
+        allowConsole: DEBUG_BUNDLE_VALUE,
+      }),
+    ].filter(Boolean)
+  },
+  {
     input: 'output/worker-thread/index.safe.js',
     output: {
       file: 'dist/worker.safe.mjs',
@@ -58,6 +74,22 @@ const ESModules = [
       MINIFY_BUNDLE_VALUE ? compiler({
         env: 'CUSTOM'
       }) : null,
+    ].filter(Boolean)
+  },
+  {
+    input: 'output/worker-thread/index.safe.js',
+    output: {
+      file: 'dist/unminified.worker.safe.mjs',
+      format: 'iife',
+      name: 'WorkerThread',
+      sourcemap: true,
+    },
+    plugins: [
+      removeTestingDocument(),
+      babelPlugin({
+        transpileToES5: false,
+        allowConsole: DEBUG_BUNDLE_VALUE,
+      }),
     ].filter(Boolean)
   },
 ];
@@ -83,6 +115,22 @@ const IIFEModules = [
     ].filter(Boolean)
   },
   {
+    input: 'output/worker-thread/index.js',
+    output: {
+      file: 'dist/unminified.worker.js',
+      format: 'iife',
+      name: 'WorkerThread',
+      sourcemap: true,
+    },
+    plugins: [
+      removeTestingDocument(),
+      babelPlugin({
+        transpileToES5: true,
+        allowConsole: DEBUG_BUNDLE_VALUE,
+      }),
+    ].filter(Boolean)
+  },
+  {
     input: 'output/worker-thread/index.safe.js',
     output: {
       file: 'dist/worker.safe.js',
@@ -100,7 +148,23 @@ const IIFEModules = [
         env: 'CUSTOM'
       }) : null,
     ].filter(Boolean)
-  }
+  },
+  {
+    input: 'output/worker-thread/index.safe.js',
+    output: {
+      file: 'dist/unminified.worker.safe.js',
+      format: 'iife',
+      name: 'WorkerThread',
+      sourcemap: true,
+    },
+    plugins: [
+      removeTestingDocument(),
+      babelPlugin({
+        transpileToES5: true,
+        allowConsole: DEBUG_BUNDLE_VALUE,
+      }),
+    ].filter(Boolean)
+  },
 ];
 
 const debugModules = DEBUG_BUNDLE_VALUE ? [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/worker-dom",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A facsimile of a modern DOM implementation intended to run in a Web Worker.",
   "main": "dist/index",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Addresses #110.

Chose the format `unminified.${filename}.${extension}` so the default would still use the minification passes that are custom to the closure compiler version in the library.