### PR TITLE
Fix Node::contains order of operations. 

### DIFF
--- a/src/test/node/contains.ts
+++ b/src/test/node/contains.ts
@@ -15,14 +15,13 @@
  */
 
 import test from 'ava';
-import { NodeType } from '../../worker-thread/dom/Node';
-import { Element } from '../../worker-thread/dom/Element';
+import { documentForTesting as document } from '../../worker-thread/dom/Document';
 
 test.beforeEach(t => {
   t.context = {
-    node: new Element(NodeType.ELEMENT_NODE, 'div', null),
-    child: new Element(NodeType.ELEMENT_NODE, 'div', null),
-    childTwo: new Element(NodeType.ELEMENT_NODE, 'div', null),
+    node: document.createElement('div'),
+    child: document.createElement('div'),
+    childTwo: document.createElement('div'),
   };
 });
 
@@ -38,11 +37,18 @@ test('returns false for a node not contained by a parent', t => {
   t.is(node.contains(child), false);
 });
 
-test('returns true for a node contained directly by a parent', t => {
+test('returns false for a node not contained by a parent', t => {
+  const { node, child } = t.context;
+
+  t.is(node.contains(child), false);
+});
+
+test('returns true for a node contained in the document', t => {
   const { node, child } = t.context;
 
   node.appendChild(child);
-  t.is(node.contains(child), true);
+  document.body.appendChild(node);
+  t.is(document.contains(node), true);
 });
 
 test('returns true for a node contained deeper within a tree', t => {

--- a/src/worker-thread/dom/Node.ts
+++ b/src/worker-thread/dom/Node.ts
@@ -178,14 +178,17 @@ export abstract class Node {
    * @return whether a Node is a descendant of a given Node
    */
   public contains(otherNode: Node | null): boolean {
+    if (otherNode === this) {
+      return true;
+    }
+
     if (this.childNodes.length > 0) {
       if (this.childNodes.includes(this)) {
         return true;
       }
       return this.childNodes.some(child => child.contains(otherNode));
     }
-
-    return otherNode === this;
+    return false;
   }
 
   /**


### PR DESCRIPTION
Currently in Node:::contains() if we return the status of checking if our children contain `otherNode` we are looking for, ignoring that we may ourselves be the node that is being searched for due to the return.

We could fix this by either caching the result of checking our children and returning the union of checking if the node itself or it's children contain the node. OR (implemented method) first check ourself to see if we are `otherNode`. The latter is implemented as it saves us checking our children nodes. 

A test has also been added.  

