### PR TITLE
Restore Windows Demo Compatibility

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -18,11 +18,11 @@ import polka from 'polka';
 import serveStatic from 'serve-static';
 import path from 'path';
 
-const { PORT = 3001, PWD } = process.env;
+const { PORT = 3001 } = process.env;
 
 polka()
-  .use(serveStatic(path.resolve(PWD)))
-  .use(serveStatic(path.resolve(PWD, 'demo')))
+  .use(serveStatic(path.resolve(__dirname)))
+  .use(serveStatic(path.resolve(__dirname, 'demo')))
   .get('/health', (req, res) => {
     res.end('OK');
   })

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint:main": "tslint -c config/tslint.json -p src/main-thread/",
     "lint": "npm-run-all --parallel lint:*",
     "predemo": "cross-env DEBUG_BUNDLE=true npm run ~rollup",
-    "demo": "node -r esm demo/server.mjs",
+    "demo": "node -r esm demo/server.js",
     "build": "cross-env MINIFY_BUNDLE=true npm run ~rollup",
     "presize": "npm run build",
     "size": "bundlesize"
@@ -99,6 +99,9 @@
       "maxSize": "7 kB"
     }
   ],
+  "esm": {
+    "cjs": true
+  },
   "files": [
     "dist"
   ]


### PR DESCRIPTION
When using the ESM loader, CJS options are disabled. This means `__dirname` is not available and we were previously relying on `PWD` from `process.env`.

Unfortunately, this doesn't work on Windows. (#119)

So, while the contents of this file is a `module`, we need to keep the `js` extension until the minimum version of node supported is 10. Node 10 is the first version to support [`url.fileURLToPath(url)`](https://nodejs.org/api/url.html#url_url_fileurltopath_url) and [`import.meta`](https://github.com/tc39/proposal-import-meta).

Once Node 10 is the default, we can move back to `mjs`, and use `import.meta` instead of the CJS value `__dirname`.