### PR TITLE
Add Support for Comment Nodes

### DIFF
--- a/demo/comments/comments.js
+++ b/demo/comments/comments.js
@@ -1,8 +1,6 @@
 const comment = document.createComment('Test');
 const el = document.createElement('div');
-const replacer = document.createElement('p');
 
-replacer.appendChild(document.createTextNode('replacer'));
 el.appendChild(document.createTextNode('bar'));
 el.classList.add('foo');
 document.body.appendChild(comment);
@@ -11,7 +9,13 @@ document.body.appendChild(el);
 let replaced = false;
 el.addEventListener('click', function() {
   if (!replaced) {
+    const replacer = document.createElement('p');
+    replacer.appendChild(document.createTextNode('replacer'));
+
     document.body.replaceChild(replacer, comment);
     replaced = true;
+  } else {
+    document.body.replaceChild(comment, document.body.getElementsByTagName('p')[0]);
+    replaced = false;
   }
 });

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,6 +16,7 @@
     <li><a href='vanilla-script/'>Vanilla JavaScript</a></li>
     <li><a href='prime-numbers/'>Prime Numbers</a></li>
     <li><a href='svg/'>SVG Rendering</a></li>
+    <li><a href='comments/'>Comment Rendering</a></li>
     <li><a href='debugger/'>Debugger</a></li>
   </ul>
   

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     {
       "path": "./dist/worker.mjs",
       "compression": "brotli",
-      "maxSize": "6 kB"
+      "maxSize": "6.5 kB"
     },
     {
       "path": "./dist/worker.safe.mjs",

--- a/src/test/comment/textContent.ts
+++ b/src/test/comment/textContent.ts
@@ -32,6 +32,7 @@ test('get textContent', t => {
 test('set textContent', t => {
   const { comment } = t.context as { comment: Comment };
 
+t.is(comment.textContent, 'default value');
   comment.textContent = 'new value';
   t.is(comment.textContent, 'new value');
 });

--- a/src/test/comment/textContent.ts
+++ b/src/test/comment/textContent.ts
@@ -32,7 +32,7 @@ test('get textContent', t => {
 test('set textContent', t => {
   const { comment } = t.context as { comment: Comment };
 
-t.is(comment.textContent, 'default value');
+  t.is(comment.textContent, 'default value');
   comment.textContent = 'new value';
   t.is(comment.textContent, 'new value');
 });

--- a/src/test/comment/textContent.ts
+++ b/src/test/comment/textContent.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'ava';
+import { Comment } from '../../worker-thread/dom/Comment';
+
+test.beforeEach(t => {
+  t.context = {
+    comment: new Comment('default value'),
+  };
+});
+
+test('get textContent', t => {
+  const { comment } = t.context as { comment: Comment };
+
+  t.is(comment.textContent, 'default value');
+});
+
+test('set textContent', t => {
+  const { comment } = t.context as { comment: Comment };
+
+  comment.textContent = 'new value';
+  t.is(comment.textContent, 'new value');
+});
+
+test('textContent matches data', t => {
+  const { comment } = t.context as { comment: Comment };
+
+  t.is(comment.data, 'default value');
+  t.is(comment.textContent, 'default value');
+
+  comment.data = 'data setter';
+  t.is(comment.data, 'data setter');
+  t.is(comment.textContent, 'data setter');
+
+  comment.textContent = 'textContent setter';
+  t.is(comment.data, 'textContent setter');
+  t.is(comment.textContent, 'textContent setter');
+});

--- a/src/test/element/innerHTML.ts
+++ b/src/test/element/innerHTML.ts
@@ -17,11 +17,15 @@
 import test from 'ava';
 import { NodeType } from '../../worker-thread/dom/Node';
 import { Element } from '../../worker-thread/dom/Element';
+import { Text } from '../../worker-thread/dom/Text';
+import { Comment } from '../../worker-thread/dom/Comment';
 
 test.beforeEach(t => {
   t.context = {
     node: new Element(NodeType.ELEMENT_NODE, 'div', null),
     child: new Element(NodeType.ELEMENT_NODE, 'div', null),
+    text: new Text('text'),
+    comment: new Comment('comment'),
   };
 });
 
@@ -38,4 +42,18 @@ test('element with a child', t => {
 
   node.appendChild(child);
   t.is(node.innerHTML, '<div></div>');
+});
+
+test('element with text', t => {
+  const { node, text } = t.context as { node: Element; text: Text };
+
+  node.appendChild(text);
+  t.is(node.innerHTML, 'text');
+});
+
+test('element with comment', t => {
+  const { node, comment } = t.context as { node: Element; comment: Comment };
+
+  node.appendChild(comment);
+  t.is(node.innerHTML, '<!--comment-->');
 });

--- a/src/test/mutationobserver/replaceChild.ts
+++ b/src/test/mutationobserver/replaceChild.ts
@@ -29,6 +29,7 @@ test.cb.serial('replaceChild mutation, only node', t => {
           target: document.body,
           removedNodes: [div],
           addedNodes: [p],
+          nextSibling: undefined,
         },
       ]);
       observer.disconnect();
@@ -39,6 +40,60 @@ test.cb.serial('replaceChild mutation, only node', t => {
   document.body.appendChild(div);
   observer.observe(document.body);
   document.body.replaceChild(p, div);
+});
+
+test.cb.serial('replaceChild mutation, replace first with second', t => {
+  const first = document.createElement('first');
+  const second = document.createElement('second');
+  const third = document.createElement('third');
+
+  const observer = new document.defaultView.MutationObserver(
+    (mutations: MutationRecord[]): void => {
+      t.deepEqual(mutations, [
+        {
+          type: MutationRecordType.CHILD_LIST,
+          target: document.body,
+          removedNodes: [first],
+          addedNodes: [second],
+          nextSibling: third,
+        },
+      ]);
+      observer.disconnect();
+      t.end();
+    },
+  );
+
+  document.body.appendChild(first);
+  document.body.appendChild(third);
+  observer.observe(document.body);
+  document.body.replaceChild(second, first);
+});
+
+test.cb.serial('replaceChild mutation, replace third with second', t => {
+  const first = document.createElement('first');
+  const second = document.createElement('second');
+  const third = document.createElement('third');
+
+  const observer = new document.defaultView.MutationObserver(
+    (mutations: MutationRecord[]): void => {
+      t.deepEqual(mutations, [
+        {
+          type: MutationRecordType.CHILD_LIST,
+          target: document.body,
+          removedNodes: [third],
+          addedNodes: [second],
+          nextSibling: undefined,
+        },
+      ]);
+      observer.disconnect();
+      t.end();
+    },
+  );
+
+  document.body.appendChild(first);
+  document.body.appendChild(third);
+  observer.observe(document.body);
+  document.body.replaceChild(second, third);
 });
 
 test.cb.serial('replaceChild mutation, remove sibling node', t => {
@@ -52,6 +107,7 @@ test.cb.serial('replaceChild mutation, remove sibling node', t => {
           target: document.body,
           removedNodes: [p],
           addedNodes: [div],
+          nextSibling: undefined,
         },
       ]);
       observer.disconnect();

--- a/src/worker-thread/dom/Comment.ts
+++ b/src/worker-thread/dom/Comment.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NodeType } from './Node';
+import { CharacterData } from './CharacterData';
+import { NumericBoolean } from '../../utils';
+import { TransferrableKeys } from '../../transfer/TransferrableKeys';
+import { HydrateableNode } from '../../transfer/TransferrableNodes';
+import { store as storeString } from '../StringMapping';
+
+// @see https://developer.mozilla.org/en-US/docs/Web/API/Comment
+export class Comment extends CharacterData {
+  constructor(data: string) {
+    super(data, NodeType.COMMENT_NODE, '#comment');
+    this._transferredFormat_ = {
+      [TransferrableKeys._index_]: this._index_,
+      [TransferrableKeys.transferred]: NumericBoolean.TRUE,
+    };
+    this._creationFormat_ = {
+      [TransferrableKeys._index_]: this._index_,
+      [TransferrableKeys.transferred]: NumericBoolean.FALSE,
+      [TransferrableKeys.nodeType]: NodeType.COMMENT_NODE,
+      [TransferrableKeys.nodeName]: storeString('#comment'),
+      [TransferrableKeys.textContent]: storeString(this.data),
+    };
+  }
+
+  public hydrate(): HydrateableNode {
+    return this._creationFormat_;
+  }
+
+  /**
+   * textContent getter, retrieves underlying CharacterData data.
+   * This is a different implmentation than DOMv1-4 APIs, but should be transparent to Frameworks.
+   */
+  get textContent(): string {
+    return this.data;
+  }
+
+  /**
+   * textContent setter, mutates underlying CharacterData data.
+   * This is a different implmentation than DOMv1-4 APIs, but should be transparent to Frameworks.
+   * @param value new value
+   */
+  set textContent(value: string) {
+    // Mutation Observation is performed by CharacterData.
+    this.nodeValue = value;
+  }
+}

--- a/src/worker-thread/dom/Document.ts
+++ b/src/worker-thread/dom/Document.ts
@@ -49,6 +49,7 @@ import { SVGElement } from './SVGElement';
 import { Node, NodeType, NamespaceURI } from './Node';
 import { Event } from '../Event';
 import { Text } from './Text';
+import { Comment } from './Comment';
 import { MutationObserver } from '../MutationObserver';
 import { observe as observeMutations } from '../../transfer/DocumentMutations';
 import { propagate as propagateEvents } from '../../transfer/TransferrableEvent';
@@ -60,6 +61,7 @@ export class Document extends Element {
     MutationObserver: typeof MutationObserver;
     Document: typeof Document;
     Node: typeof Node;
+    Comment: typeof Comment;
     Text: typeof Text;
     Element: typeof Element;
     SVGElement: typeof SVGElement;
@@ -78,11 +80,13 @@ export class Document extends Element {
     this.createElementNS = (namespaceURI: NamespaceURI, tagName: string): Element =>
       new (NODE_NAME_MAPPING[tagName] || HTMLElement)(NodeType.ELEMENT_NODE, tagName, namespaceURI);
     this.createTextNode = (text: string): Text => new Text(text);
+    this.createComment = (text: string): Comment => new Comment(text);
     this.defaultView = {
       document: this,
       MutationObserver,
       Document,
       Node,
+      Comment,
       Text,
       Element,
       SVGElement,

--- a/src/worker-thread/dom/Element.ts
+++ b/src/worker-thread/dom/Element.ts
@@ -147,7 +147,18 @@ export class Element extends Node {
     const childNodes = this.childNodes;
 
     if (childNodes.length) {
-      return childNodes.map(child => (child.nodeType === NodeType.ELEMENT_NODE ? child.outerHTML : child.textContent)).join('');
+      return childNodes
+        .map(child => {
+          switch (child.nodeType) {
+            case NodeType.TEXT_NODE:
+              return child.textContent;
+            case NodeType.COMMENT_NODE:
+              return `<!--${child.textContent}-->`;
+            default:
+              return child.outerHTML;
+          }
+        })
+        .join('');
     }
     return '';
   }

--- a/src/worker-thread/dom/Node.ts
+++ b/src/worker-thread/dom/Node.ts
@@ -298,11 +298,13 @@ export abstract class Node {
         oldChild.parentNode = null;
         propagate(oldChild, 'isConnected', false);
         this.childNodes.splice(index, 1, newChild);
+        propagate(newChild, 'isConnected', true);
 
         mutate({
           addedNodes: [newChild],
           removedNodes: [oldChild],
           type: MutationRecordType.CHILD_LIST,
+          nextSibling: this.childNodes[index + 1],
           target: this,
         });
       }


### PR DESCRIPTION
Several popular frameworks use `Comment` nodes to reserve spots in DOM for future mutations.

This PR is WIP adding support for Comment nodes.