### PR TITLE
ci: test on Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: node_js
 sudo: required
 dist: trusty
 node_js:
-  - "lts/*"
+  - "8"
+  - "10"
+  - "node"
 before_install:
   - unset _JAVA_OPTIONS  # JVM heap sizes break closure compiler
 install:


### PR DESCRIPTION
Currently `lts/*` only tests the last LTS branch but not Node.js 8 which is still LTS.