### PR TITLE
Fix casing bug with NODE_NAME_MAPPING

### DIFF
--- a/src/worker-thread/dom/Document.ts
+++ b/src/worker-thread/dom/Document.ts
@@ -51,10 +51,11 @@ import { Event } from '../Event';
 import { Text } from './Text';
 import { Comment } from './Comment';
 import { MutationObserver } from '../MutationObserver';
+import { NodeType, HTML_NAMESPACE } from '../../transfer/TransferrableNodes';
 import { observe as observeMutations } from '../../transfer/DocumentMutations';
 import { propagate as propagateEvents } from '../../transfer/TransferrableEvent';
 import { propagate as propagateSyncValues } from '../../transfer/TransferrableSyncValue';
-import { NodeType, HTML_NAMESPACE } from '../../transfer/TransferrableNodes';
+import { toLower } from '../../utils';
 
 export class Document extends Element {
   public defaultView: {
@@ -80,7 +81,7 @@ export class Document extends Element {
     this.createElement = (tagName: string): Element => this.createElementNS(HTML_NAMESPACE, tagName);
     // TODO: Add tests for case-sensitivity of NODE_NAME_MAPPING.
     this.createElementNS = (namespaceURI: NamespaceURI, tagName: string): Element =>
-      new (NODE_NAME_MAPPING[tagName.toLowerCase()] || HTMLElement)(NodeType.ELEMENT_NODE, tagName, namespaceURI);
+      new (NODE_NAME_MAPPING[toLower(tagName)] || HTMLElement)(NodeType.ELEMENT_NODE, tagName, namespaceURI);
     this.createTextNode = (text: string): Text => new Text(text);
     this.createComment = (text: string): Comment => new Comment(text);
     this.observe = (): void => {

--- a/src/worker-thread/dom/Document.ts
+++ b/src/worker-thread/dom/Document.ts
@@ -78,8 +78,9 @@ export class Document extends Element {
     super(NodeType.DOCUMENT_NODE, '#document', HTML_NAMESPACE);
     this.documentElement = this;
     this.createElement = (tagName: string): Element => this.createElementNS(HTML_NAMESPACE, tagName);
+    // TODO: Add tests for case-sensitivity of NODE_NAME_MAPPING.
     this.createElementNS = (namespaceURI: NamespaceURI, tagName: string): Element =>
-      new (NODE_NAME_MAPPING[tagName] || HTMLElement)(NodeType.ELEMENT_NODE, tagName, namespaceURI);
+      new (NODE_NAME_MAPPING[tagName.toLowerCase()] || HTMLElement)(NodeType.ELEMENT_NODE, tagName, namespaceURI);
     this.createTextNode = (text: string): Text => new Text(text);
     this.createComment = (text: string): Comment => new Comment(text);
     this.observe = (): void => {

--- a/src/worker-thread/initialize.ts
+++ b/src/worker-thread/initialize.ts
@@ -25,6 +25,7 @@ import { SVGElement } from './dom/SVGElement';
 import { set as setPhase, Phases } from '../transfer/phase';
 
 export function consumeInitialDOM(document: Document, strings: Array<string>, hydrateableNode: HydrateableNode): void {
+  // TODO(choumx): Add debugging hook for this.
   strings.forEach(string => storeString(string));
   (hydrateableNode[TransferrableKeys.childNodes] || []).forEach(child => document.body.appendChild(create(document, strings, child)));
   setPhase(Phases.Hydrating);


### PR DESCRIPTION
Browsers have uppercased tag names, so this resulted in all hydrated elements being created as `HTMLElement`. Also realized we need a test for for `Document`. :)