### PR TITLE
New version of Closure Compiler + Terser

### DIFF
--- a/config/rollup.main-thread.js
+++ b/config/rollup.main-thread.js
@@ -16,6 +16,7 @@
 
 import resolve from 'rollup-plugin-node-resolve';
 import compiler from '@ampproject/rollup-plugin-closure-compiler';
+import { terser } from 'rollup-plugin-terser';
 import {babelPlugin} from './rollup.plugins.js';
 import {MINIFY_BUNDLE_VALUE, DEBUG_BUNDLE_VALUE} from './rollup.utils.js';
 
@@ -33,6 +34,7 @@ const ESModules = [
         allowConsole: DEBUG_BUNDLE_VALUE,
       }),
       MINIFY_BUNDLE_VALUE ? compiler() : null,
+      MINIFY_BUNDLE_VALUE ? terser() : null,
     ].filter(Boolean)
   },
   {
@@ -63,6 +65,7 @@ const ESModules = [
         allowConsole: DEBUG_BUNDLE_VALUE,
       }),
       MINIFY_BUNDLE_VALUE ? compiler() : null,
+      MINIFY_BUNDLE_VALUE ? terser() : null,
     ].filter(Boolean)
   },
   {
@@ -97,6 +100,7 @@ const IIFEModules = [
         allowConsole: DEBUG_BUNDLE_VALUE,
       }),
       MINIFY_BUNDLE_VALUE ? compiler() : null,
+      MINIFY_BUNDLE_VALUE ? terser() : null,
     ].filter(Boolean)
   },
   {
@@ -129,6 +133,7 @@ const IIFEModules = [
         allowConsole: DEBUG_BUNDLE_VALUE,
       }),
       MINIFY_BUNDLE_VALUE ? compiler() : null,
+      MINIFY_BUNDLE_VALUE ? terser() : null,
     ].filter(Boolean)
   },
   {
@@ -164,6 +169,7 @@ const debugModules = DEBUG_BUNDLE_VALUE ? [
         allowConsole: true,
       }),
       MINIFY_BUNDLE_VALUE ? compiler() : null,
+      MINIFY_BUNDLE_VALUE ? terser() : null,
     ].filter(Boolean)
   }
 ] : [];

--- a/config/rollup.worker-thread.js
+++ b/config/rollup.worker-thread.js
@@ -15,8 +15,9 @@
  */
 
 import compiler from '@ampproject/rollup-plugin-closure-compiler';
-import {babelPlugin, removeTestingDocument} from './rollup.plugins.js';
-import {MINIFY_BUNDLE_VALUE, DEBUG_BUNDLE_VALUE} from './rollup.utils.js';
+import { terser } from 'rollup-plugin-terser';
+import { babelPlugin, removeTestingDocument } from './rollup.plugins.js';
+import { MINIFY_BUNDLE_VALUE, DEBUG_BUNDLE_VALUE } from './rollup.utils.js';
 
 // Workers do not natively support ES Modules containing `import` or `export` statments.
 // So, here we continue to use the '.mjs' extension to indicate newer ECMASCRIPT support
@@ -36,10 +37,13 @@ const ESModules = [
         transpileToES5: false,
         allowConsole: DEBUG_BUNDLE_VALUE,
       }),
-      MINIFY_BUNDLE_VALUE ? compiler({
-        env: 'CUSTOM'
-      }) : null,
-    ].filter(Boolean)
+      MINIFY_BUNDLE_VALUE
+        ? compiler({
+            env: 'CUSTOM',
+          })
+        : null,
+      MINIFY_BUNDLE_VALUE ? terser() : null,
+    ].filter(Boolean),
   },
   {
     input: 'output/worker-thread/index.js',
@@ -55,7 +59,7 @@ const ESModules = [
         transpileToES5: false,
         allowConsole: DEBUG_BUNDLE_VALUE,
       }),
-    ].filter(Boolean)
+    ].filter(Boolean),
   },
   {
     input: 'output/worker-thread/index.safe.js',
@@ -71,10 +75,13 @@ const ESModules = [
         transpileToES5: false,
         allowConsole: DEBUG_BUNDLE_VALUE,
       }),
-      MINIFY_BUNDLE_VALUE ? compiler({
-        env: 'CUSTOM'
-      }) : null,
-    ].filter(Boolean)
+      MINIFY_BUNDLE_VALUE
+        ? compiler({
+            env: 'CUSTOM',
+          })
+        : null,
+      MINIFY_BUNDLE_VALUE ? terser() : null,
+    ].filter(Boolean),
   },
   {
     input: 'output/worker-thread/index.safe.js',
@@ -90,7 +97,7 @@ const ESModules = [
         transpileToES5: false,
         allowConsole: DEBUG_BUNDLE_VALUE,
       }),
-    ].filter(Boolean)
+    ].filter(Boolean),
   },
 ];
 
@@ -109,10 +116,13 @@ const IIFEModules = [
         transpileToES5: true,
         allowConsole: DEBUG_BUNDLE_VALUE,
       }),
-      MINIFY_BUNDLE_VALUE ? compiler({
-        env: 'CUSTOM'
-      }) : null,
-    ].filter(Boolean)
+      MINIFY_BUNDLE_VALUE
+        ? compiler({
+            env: 'CUSTOM',
+          })
+        : null,
+      MINIFY_BUNDLE_VALUE ? terser() : null,
+    ].filter(Boolean),
   },
   {
     input: 'output/worker-thread/index.js',
@@ -128,7 +138,7 @@ const IIFEModules = [
         transpileToES5: true,
         allowConsole: DEBUG_BUNDLE_VALUE,
       }),
-    ].filter(Boolean)
+    ].filter(Boolean),
   },
   {
     input: 'output/worker-thread/index.safe.js',
@@ -144,10 +154,13 @@ const IIFEModules = [
         transpileToES5: true,
         allowConsole: DEBUG_BUNDLE_VALUE,
       }),
-      MINIFY_BUNDLE_VALUE ? compiler({
-        env: 'CUSTOM'
-      }) : null,
-    ].filter(Boolean)
+      MINIFY_BUNDLE_VALUE
+        ? compiler({
+            env: 'CUSTOM',
+          })
+        : null,
+      MINIFY_BUNDLE_VALUE ? terser() : null,
+    ].filter(Boolean),
   },
   {
     input: 'output/worker-thread/index.safe.js',
@@ -163,35 +176,36 @@ const IIFEModules = [
         transpileToES5: true,
         allowConsole: DEBUG_BUNDLE_VALUE,
       }),
-    ].filter(Boolean)
+    ].filter(Boolean),
   },
 ];
 
-const debugModules = DEBUG_BUNDLE_VALUE ? [
-  {
-    input: 'output/worker-thread/index.js',
-    output: {
-      file: 'dist/debug.worker.js',
-      format: 'iife',
-      name: 'WorkerThread',
-      sourcemap: true,
-      outro: 'window.workerDocument = documentForTesting;'
-    },
-    plugins: [
-      babelPlugin({
-        transpileToES5: false,
-        allowConsole: DEBUG_BUNDLE_VALUE,
-        allowPostMessage: false,
-      }),
-      MINIFY_BUNDLE_VALUE ? compiler({
-        env: 'CUSTOM'
-      }) : null,
-    ].filter(Boolean)
-  }
-] : [];
+const debugModules = DEBUG_BUNDLE_VALUE
+  ? [
+      {
+        input: 'output/worker-thread/index.js',
+        output: {
+          file: 'dist/debug.worker.js',
+          format: 'iife',
+          name: 'WorkerThread',
+          sourcemap: true,
+          outro: 'window.workerDocument = documentForTesting;',
+        },
+        plugins: [
+          babelPlugin({
+            transpileToES5: false,
+            allowConsole: DEBUG_BUNDLE_VALUE,
+            allowPostMessage: false,
+          }),
+          MINIFY_BUNDLE_VALUE
+            ? compiler({
+                env: 'CUSTOM',
+              })
+            : null,
+          MINIFY_BUNDLE_VALUE ? terser() : null,
+        ].filter(Boolean),
+      },
+    ]
+  : [];
 
-export default [
-  ...ESModules,
-  ...IIFEModules,
-  ...debugModules,
-];
+export default [...ESModules, ...IIFEModules, ...debugModules];

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "dompurify": "1.0.8"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "0.8.4",
+    "@ampproject/rollup-plugin-closure-compiler": "0.8.5",
     "@babel/cli": "7.2.0",
     "@babel/core": "7.1.6",
     "@babel/plugin-proposal-class-properties": "7.1.0",
@@ -71,6 +71,7 @@
     "rollup": "0.67.4",
     "rollup-plugin-babel": "4.0.3",
     "rollup-plugin-node-resolve": "3.4.0",
+    "rollup-plugin-terser": "3.0.0",
     "serve-static": "1.13.2",
     "tslint": "5.11.0",
     "typescript": "3.2.1"


### PR DESCRIPTION
By using both, we gain the logic that Closure Compiler knows (and Terser doesn't) and the mangling changes that Terser can apply that CC doesn't know yet.

Net result... .1KB saved on `worker.mjs`!