### PR TITLE
Update Rollup build plugin for Rollup 1.0 Release

### DIFF
--- a/config/rollup.plugins.js
+++ b/config/rollup.plugins.js
@@ -69,23 +69,20 @@ export function removeTestingDocument() {
     buildStart() {
       context = this;
     },
-    transformChunk: async (code) => {
+    renderChunk: async (code) => {
       const source = new MagicString(code);
+      const program = context.parse(code, { ranges: true });
 
-      if (context) {
-        const program = context.parse(code, { ranges: true });
-
-        walk.simple(program, {
-          VariableDeclarator(node) {
-            if (node.id && node.id.type === 'Identifier' && node.id.name && node.id.name === 'documentForTesting') {
-              const range = node.range;
-              if (range) {
-                source.overwrite(node.range[0], node.range[1], 'documentForTesting = undefined');
-              }
+      walk.simple(program, {
+        VariableDeclarator(node) {
+          if (node.id && node.id.type === 'Identifier' && node.id.name && node.id.name === 'documentForTesting') {
+            const range = node.range;
+            if (range) {
+              source.overwrite(node.range[0], node.range[1], 'documentForTesting = undefined');
             }
-          },
-        });
-      }
+          }
+        },
+      });
       
       return {
         code: source.toString(),

--- a/src/worker-thread/dom/Document.ts
+++ b/src/worker-thread/dom/Document.ts
@@ -134,3 +134,6 @@ export function createDocument(postMessageMethod?: Function): Document {
 
   return doc;
 }
+
+/** Should only be used for testing. */
+export const documentForTesting = createDocument();


### PR DESCRIPTION
`transformChunk` lifecycle for `Plugin` is deprecated, and has been replaced with the `renderChunk` lifecycle.

Additionally, re-added the `documentForTesting` since it's used in the debugger demo page.