### PR TITLE
Allow delegating of script fetching to caller

### DIFF
--- a/src/main-thread/callbacks.ts
+++ b/src/main-thread/callbacks.ts
@@ -16,19 +16,9 @@
 
 import { MessageFromWorker, MessageToWorker } from '../transfer/Messages';
 
-/**
- * User-configurable callbacks for worker-dom events e.g. worker messaging.
- * Useful for adding logging hooks
- */
-export interface UserCallbacks {
-  onSendMessage?: (readableMessage: Object) => void;
-  onReceiveMessage?: (readableMessage: Object) => void;
-}
-
-/**
- * System-level callbacks for worker messaging.
- */
 export interface WorkerCallbacks {
+  // Called before a message is sent to the worker.
   onSendMessage?: (message: MessageToWorker) => void;
+  // Called after a message is received from the worker.
   onReceiveMessage?: (message: MessageFromWorker) => void;
 }

--- a/src/main-thread/index.safe.ts
+++ b/src/main-thread/index.safe.ts
@@ -53,6 +53,7 @@ export function upgradeElement(baseElement: Element, workerDOMUrl: string): void
 }
 
 /**
+ * This function's API will likely change frequently. Use at your own risk!
  * @param baseElement
  * @param fetchScripts Function that returns a Promise that resolves with a tuple containing the worker script, author script, and author script URL.
  */

--- a/src/main-thread/index.safe.ts
+++ b/src/main-thread/index.safe.ts
@@ -55,8 +55,8 @@ export function upgradeElement(baseElement: Element, workerDOMUrl: string): void
 /**
  * This function's API will likely change frequently. Use at your own risk!
  * @param baseElement
- * @param fetchScripts Function that returns a Promise that resolves with a tuple containing the worker script, author script, and author script URL.
+ * @param fetchPromise Promise that resolves with a tuple containing the worker script, author script, and author script URL.
  */
-export function upgrade(baseElement: Element, fetchScripts: () => Promise<[string, string, string]>): void {
-  install(fetchScripts, baseElement as HTMLElement, wrappedCallbacks, sanitizer);
+export function upgrade(baseElement: Element, fetchPromise: Promise<[string, string, string]>): void {
+  install(fetchPromise, baseElement as HTMLElement, wrappedCallbacks, sanitizer);
 }

--- a/src/main-thread/index.safe.ts
+++ b/src/main-thread/index.safe.ts
@@ -15,40 +15,47 @@
  */
 
 import { DOMPurifySanitizer } from './DOMPurifySanitizer';
-import { UserCallbacks, WorkerCallbacks } from './callbacks';
-import { install } from './install';
+import { WorkerCallbacks } from './callbacks';
+import { fetchAndInstall, install } from './install';
 import { readableMessageFromWorker, readableMessageToWorker } from './debugging';
 
 /** Users can import this and configure the sanitizer with custom DOMPurify hooks, etc. */
 export const sanitizer = new DOMPurifySanitizer();
 
 /** Users can import this and set callback functions to add logging on worker messages, etc. */
-export const callbacks: UserCallbacks = {};
+export const callbacks: WorkerCallbacks = {};
 
-// Extra function wrapper around user callbacks to ensure that debugging.ts isn't bundled
-// in other entry points.
-const workerCallbacks: WorkerCallbacks = {
+// Wrapper around `callbacks` to ensure that debugging.ts isn't bundled into other entry points.
+const wrappedCallbacks: WorkerCallbacks = {
   onSendMessage: message => {
     if (callbacks.onSendMessage) {
       const readable = readableMessageToWorker(message);
-      callbacks.onSendMessage(readable);
+      callbacks.onSendMessage(readable as any);
     }
   },
   onReceiveMessage: message => {
     if (callbacks.onReceiveMessage) {
       const readable = readableMessageFromWorker(message);
-      callbacks.onReceiveMessage(readable);
+      callbacks.onReceiveMessage(readable as any);
     }
   },
 };
 
+/**
+ * @param baseElement
+ * @param workerDOMUrl
+ */
 export function upgradeElement(baseElement: Element, workerDOMUrl: string): void {
   const authorURL = baseElement.getAttribute('src');
   if (authorURL) {
-    upgrade(baseElement, authorURL, workerDOMUrl);
+    fetchAndInstall(baseElement as HTMLElement, authorURL, workerDOMUrl, wrappedCallbacks, sanitizer);
   }
 }
 
-export function upgrade(baseElement: Element, authorURL: string, workerDOMUrl: string): void {
-  install(baseElement as HTMLElement, authorURL, workerDOMUrl, workerCallbacks, sanitizer);
+/**
+ * @param baseElement
+ * @param fetchScripts Function that returns a Promise that resolves with a tuple containing the worker script, author script, and author script URL.
+ */
+export function upgrade(baseElement: Element, fetchScripts: () => Promise<[string, string, string]>): void {
+  install(fetchScripts, baseElement as HTMLElement, wrappedCallbacks, sanitizer);
 }

--- a/src/main-thread/index.ts
+++ b/src/main-thread/index.ts
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-import { fetchAndInstall, install } from './install';
+import { fetchAndInstall } from './install';
 
 export function upgradeElement(baseElement: Element, workerDOMUrl: string): void {
   const authorURL = baseElement.getAttribute('src');
   if (authorURL) {
-    upgrade(baseElement, authorURL, workerDOMUrl);
+    fetchAndInstall(baseElement as HTMLElement, authorURL, workerDOMUrl);
   }
-}
-
-export function upgrade(baseElement: Element, authorURL: string, workerDOMUrl: string): void {
-  fetchAndInstall(baseElement as HTMLElement, authorURL, workerDOMUrl);
 }

--- a/src/main-thread/index.ts
+++ b/src/main-thread/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { install } from './install';
+import { fetchAndInstall, install } from './install';
 
 export function upgradeElement(baseElement: Element, workerDOMUrl: string): void {
   const authorURL = baseElement.getAttribute('src');
@@ -24,5 +24,5 @@ export function upgradeElement(baseElement: Element, workerDOMUrl: string): void
 }
 
 export function upgrade(baseElement: Element, authorURL: string, workerDOMUrl: string): void {
-  install(baseElement as HTMLElement, authorURL, workerDOMUrl);
+  fetchAndInstall(baseElement as HTMLElement, authorURL, workerDOMUrl);
 }

--- a/src/main-thread/install.ts
+++ b/src/main-thread/install.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { prepareMutate, mutate } from './mutator';
-import { createWorker, fetchAndCreateWorker } from './worker';
+import { createWorker } from './worker';
 import { MutationFromWorker, MessageType, MessageFromWorker } from '../transfer/Messages';
 import { prepare as prepareNodes } from './nodes';
+import { prepareMutate, mutate } from './mutator';
+import { set as setPhase, Phases } from '../transfer/phase';
 import { TransferrableKeys } from '../transfer/TransferrableKeys';
 import { WorkerCallbacks } from './callbacks';
 
@@ -25,80 +26,63 @@ const ALLOWABLE_MESSAGE_TYPES = [MessageType.MUTATE, MessageType.HYDRATE];
 
 /**
  * @param baseElement
- * @param authorURL
- * @param workerDOMUrl
+ * @param authorScriptURL
+ * @param workerDOMURL
  * @param callbacks
  * @param sanitizer
  */
 export function fetchAndInstall(
   baseElement: HTMLElement,
-  authorURL: string,
-  workerDOMUrl: string,
+  authorScriptURL: string,
+  workerDOMURL: string,
   callbacks?: WorkerCallbacks,
   sanitizer?: Sanitizer,
 ): void {
-  preinstall_(baseElement);
-  fetchAndCreateWorker(baseElement, workerDOMUrl, authorURL, callbacks).then(worker => {
-    if (worker) {
-      postInstall_(worker, sanitizer, callbacks);
-    }
-  });
+  const fetchPromise = Promise.all([
+    // TODO(KB): Fetch Polyfill for IE11.
+    fetch(workerDOMURL).then(response => response.text()),
+    fetch(authorScriptURL).then(response => response.text()),
+    Promise.resolve(authorScriptURL),
+  ]);
+  install(fetchPromise, baseElement, callbacks, sanitizer);
 }
 
 /**
- * @param fetchScripts
+ * @param fetchPromise
  * @param baseElement
  * @param callbacks
  * @param sanitizer
  */
 export function install(
-  fetchScripts: () => Promise<[string, string, string]>,
+  fetchPromise: Promise<[string, string, string]>,
   baseElement: HTMLElement,
   callbacks?: WorkerCallbacks,
   sanitizer?: Sanitizer,
 ): void {
-  preinstall_(baseElement);
-  fetchScripts().then(([workerDOMScript, authorScript, authorScriptURL]) => {
+  prepareNodes(baseElement);
+  fetchPromise.then(([workerDOMScript, authorScript, authorScriptURL]) => {
     if (workerDOMScript && authorScript && authorScriptURL) {
-      const worker = createWorker(baseElement, workerDOMScript, authorScript, authorScriptURL);
-      postInstall_(worker, sanitizer, callbacks);
+      const worker = createWorker(baseElement, workerDOMScript, authorScript, authorScriptURL, callbacks);
+      setPhase(Phases.Hydrating);
+      prepareMutate(worker, sanitizer);
+      worker.onmessage = (message: MessageFromWorker) => {
+        const { data } = message;
+        if (!ALLOWABLE_MESSAGE_TYPES.includes(data[TransferrableKeys.type])) {
+          return;
+        }
+        // TODO(KB): Hydration has special rules limiting the types of allowed mutations.
+        // Re-introduce Hydration and add a specialized handler.
+        mutate(
+          (data as MutationFromWorker)[TransferrableKeys.nodes],
+          (data as MutationFromWorker)[TransferrableKeys.strings],
+          (data as MutationFromWorker)[TransferrableKeys.mutations],
+        );
+        // Invoke callbacks after hydrate/mutate processing so strings etc. are stored.
+        if (callbacks && callbacks.onReceiveMessage) {
+          callbacks.onReceiveMessage(message);
+        }
+      };
     }
     return null;
   });
-}
-
-/**
- * @param baseElement
- */
-function preinstall_(baseElement: HTMLElement): void {
-  prepareNodes(baseElement);
-}
-
-/**
- * @param worker
- * @param sanitizer
- * @param callbacks
- */
-function postInstall_(worker: Worker, sanitizer?: Sanitizer, callbacks?: WorkerCallbacks): void {
-  prepareMutate(worker, sanitizer);
-
-  worker.onmessage = (message: MessageFromWorker) => {
-    const { data } = message;
-
-    if (!ALLOWABLE_MESSAGE_TYPES.includes(data[TransferrableKeys.type])) {
-      return;
-    }
-    // TODO(KB): Hydration has special rules limiting the types of allowed mutations.
-    // Re-introduce Hydration and add a specialized handler.
-    mutate(
-      (data as MutationFromWorker)[TransferrableKeys.nodes],
-      (data as MutationFromWorker)[TransferrableKeys.strings],
-      (data as MutationFromWorker)[TransferrableKeys.mutations],
-    );
-
-    // Invoke callbacks after hydrate/mutate processing so strings etc. are stored.
-    if (callbacks && callbacks.onReceiveMessage) {
-      callbacks.onReceiveMessage(message);
-    }
-  };
 }

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -15,7 +15,6 @@
  */
 
 import { MessageToWorker } from '../transfer/Messages';
-import { set as setPhase, Phases } from '../transfer/phase';
 import { createHydrateableNode, initialStrings } from './serialize';
 import { WorkerCallbacks } from './callbacks';
 
@@ -26,37 +25,21 @@ import { WorkerCallbacks } from './callbacks';
 let callbacks_: WorkerCallbacks | undefined;
 
 /**
- * TODO(KB): Fetch Polyfill for IE11.
- * @param baseElement
- * @param workerDOMURL
- * @param authorScriptURL
- * @param callbacks
- */
-export function fetchAndCreateWorker(
-  baseElement: HTMLElement,
-  workerDOMURL: string,
-  authorScriptURL: string,
-  callbacks?: WorkerCallbacks,
-): Promise<Worker | null> {
-  callbacks_ = callbacks;
-  return Promise.all([fetch(workerDOMURL).then(response => response.text()), fetch(authorScriptURL).then(response => response.text())])
-    .then(([workerDOMScript, authorScript]) => {
-      const worker = createWorker(baseElement, workerDOMScript, authorScript, authorScriptURL);
-      setPhase(Phases.Hydrating);
-      return worker;
-    })
-    .catch(error => {
-      return null;
-    });
-}
-
-/**
+ * Also stores `callbacks` in a global.
  * @param baseElement
  * @param workerDOMScript
  * @param authorScript
  * @param authorScriptURL
  */
-export function createWorker(baseElement: HTMLElement, workerDOMScript: string, authorScript: string, authorScriptURL: string): Worker {
+export function createWorker(
+  baseElement: HTMLElement,
+  workerDOMScript: string,
+  authorScript: string,
+  authorScriptURL: string,
+  callbacks?: WorkerCallbacks,
+): Worker {
+  callbacks_ = callbacks;
+
   // TODO(KB): Minify this output during build process.
   const keys: Array<string> = [];
   const hydratedNode = createHydrateableNode(baseElement);

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -25,58 +25,75 @@ import { WorkerCallbacks } from './callbacks';
  */
 let callbacks_: WorkerCallbacks | undefined;
 
-// TODO(KB): Fetch Polyfill for IE11.
-export function createWorker(
+/**
+ * TODO(KB): Fetch Polyfill for IE11.
+ * @param baseElement
+ * @param workerDOMURL
+ * @param authorScriptURL
+ * @param callbacks
+ */
+export function fetchAndCreateWorker(
   baseElement: HTMLElement,
-  workerDomURL: string,
+  workerDOMURL: string,
   authorScriptURL: string,
   callbacks?: WorkerCallbacks,
 ): Promise<Worker | null> {
   callbacks_ = callbacks;
-  return Promise.all([fetch(workerDomURL).then(response => response.text()), fetch(authorScriptURL).then(response => response.text())])
-    .then(([workerScript, authorScript]) => {
-      // TODO(KB): Minify this output during build process.
-      const keys: Array<string> = [];
-      const hydratedNode = createHydrateableNode(baseElement);
-      for (const key in document.body.style) {
-        keys.push(`'${key}'`);
-      }
-      const code = `
-        'use strict';
-        ${workerScript}
-        (function() {
-          var self = this;
-          var window = this;
-          var document = this.document;
-          var localStorage = this.localStorage;
-          var location = this.location;
-          var defaultView = document.defaultView;
-          var Node = defaultView.Node;
-          var Text = defaultView.Text;
-          var Element = defaultView.Element;
-          var SVGElement = defaultView.SVGElement;
-          var Document = defaultView.Document;
-          var Event = defaultView.Event;
-          var MutationObserver = defaultView.MutationObserver;
-
-          function addEventListener(type, handler) {
-            return document.addEventListener(type, handler);
-          }
-          function removeEventListener(type, handler) {
-            return document.removeEventListener(type, handler);
-          }
-          this.consumeInitialDOM(document, ${JSON.stringify(initialStrings)}, ${JSON.stringify(hydratedNode)});
-          this.appendKeys([${keys}]);
-          document.observe();
-          ${authorScript}
-        }).call(WorkerThread.workerDOM);
-//# sourceURL=${encodeURI(authorScriptURL)}`;
+  return Promise.all([fetch(workerDOMURL).then(response => response.text()), fetch(authorScriptURL).then(response => response.text())])
+    .then(([workerDOMScript, authorScript]) => {
+      const worker = createWorker(baseElement, workerDOMScript, authorScript, authorScriptURL);
       setPhase(Phases.Hydrating);
-      return new Worker(URL.createObjectURL(new Blob([code])));
+      return worker;
     })
     .catch(error => {
       return null;
     });
+}
+
+/**
+ * @param baseElement
+ * @param workerDOMScript
+ * @param authorScript
+ * @param authorScriptURL
+ */
+export function createWorker(baseElement: HTMLElement, workerDOMScript: string, authorScript: string, authorScriptURL: string): Worker {
+  // TODO(KB): Minify this output during build process.
+  const keys: Array<string> = [];
+  const hydratedNode = createHydrateableNode(baseElement);
+  for (const key in document.body.style) {
+    keys.push(`'${key}'`);
+  }
+  const code = `
+    'use strict';
+    ${workerDOMScript}
+    (function() {
+      var self = this;
+      var window = this;
+      var document = this.document;
+      var localStorage = this.localStorage;
+      var location = this.location;
+      var defaultView = document.defaultView;
+      var Node = defaultView.Node;
+      var Text = defaultView.Text;
+      var Element = defaultView.Element;
+      var SVGElement = defaultView.SVGElement;
+      var Document = defaultView.Document;
+      var Event = defaultView.Event;
+      var MutationObserver = defaultView.MutationObserver;
+
+      function addEventListener(type, handler) {
+        return document.addEventListener(type, handler);
+      }
+      function removeEventListener(type, handler) {
+        return document.removeEventListener(type, handler);
+      }
+      this.consumeInitialDOM(document, ${JSON.stringify(initialStrings)}, ${JSON.stringify(hydratedNode)});
+      this.appendKeys([${keys}]);
+      document.observe();
+      ${authorScript}
+    }).call(WorkerThread.workerDOM);
+//# sourceURL=${encodeURI(authorScriptURL)}`;
+  return new Worker(URL.createObjectURL(new Blob([code])));
 }
 
 /**


### PR DESCRIPTION
This allows AMP to perform the fetch of worker/author scripts which:

1. Avoids need for a fetch polyfill.
2. Allows AMP to set its typical request headers and query params.
3. Enforce a size constraint on the author script.

/to @kristoferbaxter 