### PR TITLE
Free initial strings after worker creation

### DIFF
--- a/src/main-thread/serialize.ts
+++ b/src/main-thread/serialize.ts
@@ -19,40 +19,47 @@ import { TransferrableKeys } from '../transfer/TransferrableKeys';
 import { NumericBoolean } from '../utils';
 
 const NODES_ALLOWED_TO_TRANSMIT_TEXT_CONTENT = [NodeType.COMMENT_NODE, NodeType.TEXT_NODE];
-export const initialStrings: Array<string> = [];
-const strings: Map<string, number> = new Map();
-let count = 0;
 
-function store(value: string): number {
-  if (strings.has(value)) {
+function store(value: string, strings: Array<string>, stringMap: Map<string, number>): number {
+  if (stringMap.has(value)) {
     // Safe to cast since we verified the mapping contains the value
-    return (strings.get(value) as number) - 1;
+    return stringMap.get(value) as number;
   }
-  strings.set(value, ++count);
-  initialStrings.push(value);
+  const count = strings.length;
+  stringMap.set(value, count);
+  strings.push(value);
 
-  return count - 1;
+  return count;
 }
 
-export function createHydrateableNode(element: RenderableElement): HydrateableNode {
-  let hydrated: HydrateableNode = {
+function createHydrateableNode(element: RenderableElement, strings: Array<string>, stringMap: Map<string, number>): HydrateableNode {
+  const hydrated: HydrateableNode = {
     [TransferrableKeys.index]: element._index_,
     [TransferrableKeys.transferred]: NumericBoolean.FALSE,
     [TransferrableKeys.nodeType]: element.nodeType,
-    [TransferrableKeys.nodeName]: store(element.nodeName),
-    [TransferrableKeys.childNodes]: [].map.call(element.childNodes || [], (child: RenderableElement) => createHydrateableNode(child)),
+    [TransferrableKeys.nodeName]: store(element.nodeName, strings, stringMap),
+    [TransferrableKeys.childNodes]: [].map.call(element.childNodes || [], (child: RenderableElement) =>
+      createHydrateableNode(child, strings, stringMap),
+    ),
     [TransferrableKeys.attributes]: [].map.call(element.attributes || [], (attribute: Attr) => [
-      store(attribute.namespaceURI || 'null'),
-      store(attribute.name),
-      store(attribute.value),
+      store(attribute.namespaceURI || 'null', strings, stringMap),
+      store(attribute.name, strings, stringMap),
+      store(attribute.value, strings, stringMap),
     ]),
   };
   if (element.namespaceURI !== null) {
-    hydrated[TransferrableKeys.namespaceURI] = store(element.namespaceURI);
+    hydrated[TransferrableKeys.namespaceURI] = store(element.namespaceURI, strings, stringMap);
   }
   if (NODES_ALLOWED_TO_TRANSMIT_TEXT_CONTENT.includes(element.nodeType) && (element as Text).textContent !== null) {
-    hydrated[TransferrableKeys.textContent] = store(element.textContent as string);
+    hydrated[TransferrableKeys.textContent] = store(element.textContent as string, strings, stringMap);
   }
 
   return hydrated;
+}
+
+export function createHydrateableRootNode(element: RenderableElement): { skeleton: HydrateableNode; strings: Array<string> } {
+  const strings: Array<string> = [];
+  const stringMap: Map<string, number> = new Map();
+  const skeleton = createHydrateableNode(element, strings, stringMap);
+  return { skeleton, strings };
 }

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -15,7 +15,7 @@
  */
 
 import { MessageToWorker } from '../transfer/Messages';
-import { createHydrateableNode, initialStrings } from './serialize';
+import { createHydrateableRootNode } from './serialize';
 import { WorkerCallbacks } from './callbacks';
 
 /**
@@ -42,9 +42,9 @@ export function createWorker(
 
   // TODO(KB): Minify this output during build process.
   const keys: Array<string> = [];
-  const hydratedNode = createHydrateableNode(baseElement);
+  const { skeleton, strings } = createHydrateableRootNode(baseElement);
   for (const key in document.body.style) {
-    keys.push(`'${key}'`);
+    keys.push(key);
   }
   const code = `
     'use strict';
@@ -70,8 +70,8 @@ export function createWorker(
       function removeEventListener(type, handler) {
         return document.removeEventListener(type, handler);
       }
-      this.consumeInitialDOM(document, ${JSON.stringify(initialStrings)}, ${JSON.stringify(hydratedNode)});
-      this.appendKeys([${keys}]);
+      this.consumeInitialDOM(document, ${JSON.stringify(strings)}, ${JSON.stringify(skeleton)});
+      this.appendKeys(${JSON.stringify(keys)});
       document.observe();
       ${authorScript}
     }).call(WorkerThread.workerDOM);


### PR DESCRIPTION
The current module-level `initialStrings` and `strings` are never freed. This reworks the code so they're stack allocated objects, and will be cleaned up after creating the worker.