### PR TITLE
Use an array backing for strings

### DIFF
--- a/src/main-thread/strings.ts
+++ b/src/main-thread/strings.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-let count: number = 0;
-const strings: Map<number, string> = new Map();
+const strings: Array<string> = [];
 
 /**
  * Return a string for the specified index.
@@ -23,7 +22,7 @@ const strings: Map<number, string> = new Map();
  * @returns string in map for the index.
  */
 export function get(index: number): string {
-  return strings.get(index) || '';
+  return strings[index] || '';
 }
 
 /**
@@ -32,5 +31,5 @@ export function get(index: number): string {
  * @return location in map
  */
 export function store(value: string): void {
-  strings.set(++count, value);
+  strings.push(value);
 }

--- a/src/test/htmlelement/serialize.ts
+++ b/src/test/htmlelement/serialize.ts
@@ -17,7 +17,7 @@
 import anyTest, { TestInterface } from 'ava';
 import { HydrateableNode, NodeType, SVG_NAMESPACE } from '../../transfer/TransferrableNodes';
 import { TransferrableKeys } from '../../transfer/TransferrableKeys';
-import { get } from '../../worker-thread/strings';
+import { getForTesting as get } from '../../worker-thread/strings';
 import { createDocument, Document } from '../../worker-thread/dom/Document';
 import { HTMLElement } from '../../worker-thread/dom/HTMLElement';
 

--- a/src/test/mutationobserver/addEventListener.ts
+++ b/src/test/mutationobserver/addEventListener.ts
@@ -19,7 +19,7 @@ import { createDocument, Document } from '../../worker-thread/dom/Document';
 import { Element } from '../../worker-thread/dom/Element';
 import { MutationRecord, MutationRecordType } from '../../worker-thread/MutationRecord';
 import { TransferrableKeys } from '../../transfer/TransferrableKeys';
-import { get } from '../../worker-thread/strings';
+import { getForTesting as get } from '../../worker-thread/strings';
 
 const test = anyTest as TestInterface<{
   document: Document;

--- a/src/test/mutationobserver/removeEventListener.ts
+++ b/src/test/mutationobserver/removeEventListener.ts
@@ -19,7 +19,7 @@ import { createDocument, Document } from '../../worker-thread/dom/Document';
 import { Element } from '../../worker-thread/dom/Element';
 import { MutationRecord, MutationRecordType } from '../../worker-thread/MutationRecord';
 import { TransferrableKeys } from '../../transfer/TransferrableKeys';
-import { get } from '../../worker-thread/strings';
+import { getForTesting as get } from '../../worker-thread/strings';
 
 const test = anyTest as TestInterface<{
   document: Document;

--- a/src/worker-thread/strings.ts
+++ b/src/worker-thread/strings.ts
@@ -29,9 +29,9 @@ export function store(value: string): number {
     return mapping.get(value) as number;
   }
 
-  mapping.set(value, ++count);
+  mapping.set(value, count);
   transfer.push(value);
-  return count;
+  return count++;
 }
 
 /**
@@ -39,7 +39,7 @@ export function store(value: string): number {
  * @param value string value we need to know the index of
  * @returns index in the map for the string
  */
-export function get(value: string): number | undefined {
+export function getForTesting(value: string): number | undefined {
   return mapping.get(value);
 }
 


### PR DESCRIPTION
Arrays are a much more efficient backing store for this use case: http://jsbench.github.io/#7c89704a2ed38b0746c8d52431de7bb6