### PR TITLE
Add hydration callback

### DIFF
--- a/src/main-thread/callbacks.ts
+++ b/src/main-thread/callbacks.ts
@@ -19,6 +19,8 @@ import { MessageFromWorker, MessageToWorker } from '../transfer/Messages';
 export interface WorkerCallbacks {
   // Called when worker consumes the page's initial DOM state.
   onCreateWorker?: (initialDOM: RenderableElement) => void;
+  // Called when the worker is hydrated (sends a HYDRATE message).
+  onHydration?: () => void;
   // Called before a message is sent to the worker.
   onSendMessage?: (message: MessageToWorker) => void;
   // Called after a message is received from the worker.

--- a/src/main-thread/index.safe.ts
+++ b/src/main-thread/index.safe.ts
@@ -33,6 +33,11 @@ const wrappedCallbacks: WorkerCallbacks = {
       callbacks.onCreateWorker(readable as any);
     }
   },
+  onHydration: () => {
+    if (callbacks.onHydration) {
+      callbacks.onHydration();
+    }
+  },
   onSendMessage: message => {
     if (callbacks.onSendMessage) {
       const readable = readableMessageToWorker(message);

--- a/src/main-thread/install.ts
+++ b/src/main-thread/install.ts
@@ -67,7 +67,8 @@ export function install(
       prepareMutate(worker, sanitizer);
       worker.onmessage = (message: MessageFromWorker) => {
         const { data } = message;
-        if (!ALLOWABLE_MESSAGE_TYPES.includes(data[TransferrableKeys.type])) {
+        const type = data[TransferrableKeys.type];
+        if (!ALLOWABLE_MESSAGE_TYPES.includes(type)) {
           return;
         }
         // TODO(KB): Hydration has special rules limiting the types of allowed mutations.
@@ -78,8 +79,13 @@ export function install(
           (data as MutationFromWorker)[TransferrableKeys.mutations],
         );
         // Invoke callbacks after hydrate/mutate processing so strings etc. are stored.
-        if (callbacks && callbacks.onReceiveMessage) {
-          callbacks.onReceiveMessage(message);
+        if (callbacks) {
+          if (type === MessageType.HYDRATE && callbacks.onHydration) {
+            callbacks.onHydration();
+          }
+          if (callbacks.onReceiveMessage) {
+            callbacks.onReceiveMessage(message);
+          }
         }
       };
     }


### PR DESCRIPTION
Allows callers to apply pre-hydration UX (e.g. partial opacity) to signal non-interactivity to users.