### PR TITLE
Support multiple worker-dom roots in the main thread

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -13,13 +13,14 @@
   <h3>Basic</h3>
   <ul>
     <li><a href='hello-world/'>Hello World</a></li>
+    <li><a href='two-roots/'>Two Roots</a></li>
     <li><a href='vanilla-script/'>Vanilla JavaScript</a></li>
     <li><a href='prime-numbers/'>Prime Numbers</a></li>
     <li><a href='svg/'>SVG Rendering</a></li>
     <li><a href='comments/'>Comment Rendering</a></li>
     <li><a href='debugger/'>Debugger</a></li>
   </ul>
-  
+
   <h3>Frameworks</h3>
   <ul>
     <li><a href='preact-map/'>Interactive Map Preact</a></li>

--- a/demo/two-roots/index.html
+++ b/demo/two-roots/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Two Roots</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="/demo.css" rel="stylesheet">
+  <script src="/dist/index.mjs" type="module"></script>
+  <script src="/dist/index.js" nomodule defer></script>
+  <!-- This comment block is intended to make it easier to test both the script module and nomodule path -->
+  <!-- Comment either block to enable module/nomodule or disable it. -->
+  <!-- <script src="/dist/index.js" defer></script> -->
+  <style>
+    .upgrade-me {
+      margin: 8px;
+      padding: 8px;
+      border: 1px dashed lightgray;
+    }
+  </style>
+</head>
+<body>
+  <div src="two-roots.js" class="upgrade-me" id="upgrade-me-1">
+    <div class="root">
+      Root 1
+      <button>Update</button>
+      <div id="info">info...</div>
+    </div>
+  </div>
+  <!--
+  -->
+  <div src="two-roots.js" class="upgrade-me" id="upgrade-me-2">
+    <div class="root">
+      Root 2
+      <button>Update</button>
+      <div id="info">info...</div>
+    </div>
+  </div>
+  <script type="module">
+    import {upgradeElement} from '/dist/index.mjs';
+    document.querySelectorAll('.upgrade-me').forEach(function(element) {
+      upgradeElement(element, '/dist/worker.mjs');
+    });
+  </script>
+  <script nomodule async=false defer>
+    document.addEventListener('DOMContentLoaded', function() {
+      document.querySelectorAll('.upgrade-me').forEach(function(element) {
+        MainThread.upgradeElement(element, '/dist/worker.js');
+      });
+    }, false);
+  </script>
+  <!-- This comment block is intended to make it easier to test both the script module and nomodule path -->
+  <!-- Comment either block to enable module/nomodule or disable it. -->
+  <!-- <script async=false defer>
+    document.addEventListener('DOMContentLoaded', function() {
+      MainThread.upgradeElement(document.getElementById('upgrade-me-1'), './dist/worker.js');
+    }, false);
+  </script> -->
+</body>
+</html>

--- a/demo/two-roots/two-roots.js
+++ b/demo/two-roots/two-roots.js
@@ -15,11 +15,9 @@
  */
 
 const btn = document.getElementsByTagName('button')[0];
-console.log('QQQQ: ', document.querySelectorAll('button'));
 
 btn.addEventListener('click', async () => {
   const infoEl = document.getElementById('info');
   const boundingClientRect = await infoEl.getBoundingClientRectAsync();
-  console.log('QQQ: returned bcr: ', boundingClientRect, JSON.stringify(boundingClientRect));
   infoEl.textContent = JSON.stringify(boundingClientRect);
 });

--- a/demo/two-roots/two-roots.js
+++ b/demo/two-roots/two-roots.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const btn = document.getElementsByTagName('button')[0];
+console.log('QQQQ: ', document.querySelectorAll('button'));
+
+btn.addEventListener('click', async () => {
+  const infoEl = document.getElementById('info');
+  const boundingClientRect = await infoEl.getBoundingClientRectAsync();
+  console.log('QQQ: returned bcr: ', boundingClientRect, JSON.stringify(boundingClientRect));
+  infoEl.textContent = JSON.stringify(boundingClientRect);
+});

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     {
       "path": "./dist/index.mjs",
       "compression": "brotli",
-      "maxSize": "2 kB"
+      "maxSize": "2.8 kB"
     },
     {
       "path": "./dist/index.safe.mjs",

--- a/src/main-thread/DOMPurifySanitizer.ts
+++ b/src/main-thread/DOMPurifySanitizer.ts
@@ -16,7 +16,7 @@
 
 import purify from 'dompurify';
 
-const propertyToAttribute: { [key: string]: string } = {}; // TODO(choumx): Fill this in.
+const PROPERTY_TO_ATTRIBUTE: { [key: string]: string } = {}; // TODO(choumx): Fill this in.
 
 /**
  * Object containing optional callbacks. Use this to configure
@@ -99,7 +99,7 @@ export class DOMPurifySanitizer implements Sanitizer {
    * @param value
    */
   validProperty(tag: string, prop: string, value: string): boolean {
-    const attr = propertyToAttribute[prop];
+    const attr = PROPERTY_TO_ATTRIBUTE[prop];
     if (attr) {
       return this.validAttribute(tag, attr, value);
     } else {

--- a/src/main-thread/commands/bounding-client-rect.ts
+++ b/src/main-thread/commands/bounding-client-rect.ts
@@ -22,16 +22,16 @@ import { NumericBoolean } from '../../utils';
 import { WorkerContext } from '../worker';
 
 export class BoundingClientRectProcessor {
-  nodeContext_: NodeContext;
-  workerContext_: WorkerContext;
+  private nodeContext: NodeContext;
+  private workerContext: WorkerContext;
 
   /**
    * @param nodeContext
    * @param workerContext whom to dispatch events toward.
    */
   constructor(nodeContext: NodeContext, workerContext: WorkerContext) {
-    this.nodeContext_ = nodeContext;
-    this.workerContext_ = workerContext;
+    this.nodeContext = nodeContext;
+    this.workerContext = workerContext;
   }
 
   /**
@@ -40,7 +40,7 @@ export class BoundingClientRectProcessor {
    */
   process(mutation: TransferrableMutationRecord): void {
     const nodeId = mutation[TransferrableKeys.target];
-    const target = this.nodeContext_.getNode(nodeId);
+    const target = this.nodeContext.getNode(nodeId);
 
     if (!target) {
       console.error('getNode() yields a null value. Node id (' + nodeId + ') was not found.');
@@ -48,7 +48,7 @@ export class BoundingClientRectProcessor {
     }
 
     const boundingRect = target.getBoundingClientRect();
-    this.workerContext_.messageToWorker({
+    this.workerContext.messageToWorker({
       [TransferrableKeys.type]: MessageType.GET_BOUNDING_CLIENT_RECT,
       [TransferrableKeys.target]: {
         [TransferrableKeys.index]: target._index_,

--- a/src/main-thread/commands/bounding-client-rect.ts
+++ b/src/main-thread/commands/bounding-client-rect.ts
@@ -16,33 +16,52 @@
 
 import { TransferrableMutationRecord } from '../../transfer/TransferrableRecord';
 import { TransferrableKeys } from '../../transfer/TransferrableKeys';
-import { getNode } from '../nodes';
-import { messageToWorker } from '../worker';
 import { MessageType } from '../../transfer/Messages';
+import { NodeContext } from '../nodes';
 import { NumericBoolean } from '../../utils';
+import { WorkerContext } from '../worker';
 
-/**
- * Process commands transfered from worker thread to main thread.
- * @param nodesInstance nodes instance to execute commands against.
- * @param worker whom to dispatch events toward.
- * @param mutation mutation record containing commands to execute.
- */
-export function process(worker: Worker, mutation: TransferrableMutationRecord): void {
-  const nodeId = mutation[TransferrableKeys.target];
-  const target = getNode(nodeId);
+export class BoundingClientRectProcessor {
+  nodeContext_: NodeContext;
+  workerContext_: WorkerContext;
 
-  if (!target) {
-    console.error('getNode() yields a null value. Node id (' + nodeId + ') was not found.');
-    return;
+  /**
+   * @param nodeContext
+   * @param workerContext whom to dispatch events toward.
+   */
+  constructor(nodeContext: NodeContext, workerContext: WorkerContext) {
+    this.nodeContext_ = nodeContext;
+    this.workerContext_ = workerContext;
   }
 
-  const boundingRect = target.getBoundingClientRect();
-  messageToWorker(worker, {
-    [TransferrableKeys.type]: MessageType.GET_BOUNDING_CLIENT_RECT,
-    [TransferrableKeys.target]: {
-      [TransferrableKeys.index]: target._index_,
-      [TransferrableKeys.transferred]: NumericBoolean.TRUE,
-    },
-    [TransferrableKeys.data]: [boundingRect.top, boundingRect.right, boundingRect.bottom, boundingRect.left, boundingRect.width, boundingRect.height],
-  });
+  /**
+   * Process commands transfered from worker thread to main thread.
+   * @param mutation mutation record containing commands to execute.
+   */
+  process(mutation: TransferrableMutationRecord): void {
+    const nodeId = mutation[TransferrableKeys.target];
+    const target = this.nodeContext_.getNode(nodeId);
+
+    if (!target) {
+      console.error('getNode() yields a null value. Node id (' + nodeId + ') was not found.');
+      return;
+    }
+
+    const boundingRect = target.getBoundingClientRect();
+    this.workerContext_.messageToWorker({
+      [TransferrableKeys.type]: MessageType.GET_BOUNDING_CLIENT_RECT,
+      [TransferrableKeys.target]: {
+        [TransferrableKeys.index]: target._index_,
+        [TransferrableKeys.transferred]: NumericBoolean.TRUE,
+      },
+      [TransferrableKeys.data]: [
+        boundingRect.top,
+        boundingRect.right,
+        boundingRect.bottom,
+        boundingRect.left,
+        boundingRect.width,
+        boundingRect.height,
+      ],
+    });
+  }
 }

--- a/src/main-thread/commands/event-subscription.ts
+++ b/src/main-thread/commands/event-subscription.ts
@@ -23,17 +23,17 @@ import { TransferrableMutationRecord } from '../../transfer/TransferrableRecord'
 import { WorkerContext } from '../worker';
 
 export class EventSubscriptionProcessor {
-  strings_: Strings;
-  nodeContext_: NodeContext;
-  workerContext_: WorkerContext;
+  private strings: Strings;
+  private nodeContext: NodeContext;
+  private workerContext: WorkerContext;
   // TODO(choumx): Support SYNC events for properties other than 'value', e.g. 'checked'.
-  knownListeners_: Array<(event: Event) => any>;
+  private knownListeners: Array<(event: Event) => any>;
 
   constructor(strings: Strings, nodeContext: NodeContext, workerContext: WorkerContext) {
-    this.strings_ = strings;
-    this.nodeContext_ = nodeContext;
-    this.workerContext_ = workerContext;
-    this.knownListeners_ = [];
+    this.strings = strings;
+    this.nodeContext = nodeContext;
+    this.workerContext = workerContext;
+    this.knownListeners = [];
   }
 
   /**
@@ -42,7 +42,7 @@ export class EventSubscriptionProcessor {
    */
   process(mutation: TransferrableMutationRecord): void {
     const nodeId = mutation[TransferrableKeys.target];
-    const target = this.nodeContext_.getNode(nodeId);
+    const target = this.nodeContext.getNode(nodeId);
 
     if (!target) {
       console.error('getNode() yields a null value. Node id (' + nodeId + ') was not found.');
@@ -50,10 +50,10 @@ export class EventSubscriptionProcessor {
     }
 
     (mutation[TransferrableKeys.removedEvents] || []).forEach(eventSub =>
-      this.processListenerChange_(target, false, this.strings_.get(eventSub[TransferrableKeys.type]), eventSub[TransferrableKeys.index]),
+      this.processListenerChange(target, false, this.strings.get(eventSub[TransferrableKeys.type]), eventSub[TransferrableKeys.index]),
     );
     (mutation[TransferrableKeys.addedEvents] || []).forEach(eventSub =>
-      this.processListenerChange_(target, true, this.strings_.get(eventSub[TransferrableKeys.type]), eventSub[TransferrableKeys.index]),
+      this.processListenerChange(target, true, this.strings.get(eventSub[TransferrableKeys.type]), eventSub[TransferrableKeys.index]),
     );
   }
 
@@ -65,7 +65,7 @@ export class EventSubscriptionProcessor {
    * @param type event type requested to change
    * @param index number in the listeners array this event corresponds to.
    */
-  processListenerChange_(target: RenderableElement, addEvent: boolean, type: string, index: number): void {
+  private processListenerChange(target: RenderableElement, addEvent: boolean, type: string, index: number): void {
     let changeEventSubscribed: boolean = target.onchange !== null;
     const shouldTrack: boolean = shouldTrackChanges(target as HTMLElement);
     const isChangeEvent = type === 'change';
@@ -75,15 +75,15 @@ export class EventSubscriptionProcessor {
         changeEventSubscribed = true;
         target.onchange = null;
       }
-      (target as HTMLElement).addEventListener(type, (this.knownListeners_[index] = eventHandler(this.workerContext_, target._index_)));
+      (target as HTMLElement).addEventListener(type, (this.knownListeners[index] = eventHandler(this.workerContext, target._index_)));
     } else {
       if (isChangeEvent) {
         changeEventSubscribed = false;
       }
-      (target as HTMLElement).removeEventListener(type, this.knownListeners_[index]);
+      (target as HTMLElement).removeEventListener(type, this.knownListeners[index]);
     }
     if (shouldTrack && !changeEventSubscribed) {
-      applyDefaultChangeListener(this.workerContext_, target as RenderableElement);
+      applyDefaultChangeListener(this.workerContext, target as RenderableElement);
     }
   }
 }

--- a/src/main-thread/commands/event-subscription.ts
+++ b/src/main-thread/commands/event-subscription.ts
@@ -14,16 +14,79 @@
  * limitations under the License.
  */
 
-import { messageToWorker } from '../worker';
-import { TransferrableKeys } from '../../transfer/TransferrableKeys';
 import { MessageType } from '../../transfer/Messages';
 import { NumericBoolean } from '../../utils';
-import { getNode } from '../nodes';
+import { NodeContext } from '../nodes';
+import { Strings } from '../strings';
+import { TransferrableKeys } from '../../transfer/TransferrableKeys';
 import { TransferrableMutationRecord } from '../../transfer/TransferrableRecord';
-import { get as getString } from '../strings';
+import { WorkerContext } from '../worker';
 
-// TODO(choumx): Support SYNC events for properties other than 'value', e.g. 'checked'.
-const KNOWN_LISTENERS: Array<(event: Event) => any> = [];
+export class EventSubscriptionProcessor {
+  strings_: Strings;
+  nodeContext_: NodeContext;
+  workerContext_: WorkerContext;
+  // TODO(choumx): Support SYNC events for properties other than 'value', e.g. 'checked'.
+  knownListeners_: Array<(event: Event) => any>;
+
+  constructor(strings: Strings, nodeContext: NodeContext, workerContext: WorkerContext) {
+    this.strings_ = strings;
+    this.nodeContext_ = nodeContext;
+    this.workerContext_ = workerContext;
+    this.knownListeners_ = [];
+  }
+
+  /**
+   * Process event subscription changes transfered from worker thread to main thread.
+   * @param mutation mutation record containing commands to execute.
+   */
+  process(mutation: TransferrableMutationRecord): void {
+    const nodeId = mutation[TransferrableKeys.target];
+    const target = this.nodeContext_.getNode(nodeId);
+
+    if (!target) {
+      console.error('getNode() yields a null value. Node id (' + nodeId + ') was not found.');
+      return;
+    }
+
+    (mutation[TransferrableKeys.removedEvents] || []).forEach(eventSub =>
+      this.processListenerChange_(target, false, this.strings_.get(eventSub[TransferrableKeys.type]), eventSub[TransferrableKeys.index]),
+    );
+    (mutation[TransferrableKeys.addedEvents] || []).forEach(eventSub =>
+      this.processListenerChange_(target, true, this.strings_.get(eventSub[TransferrableKeys.type]), eventSub[TransferrableKeys.index]),
+    );
+  }
+
+  /**
+   * If the worker requests to add an event listener to 'change' for something the foreground thread is already listening to,
+   * ensure that only a single 'change' event is attached to prevent sending values multiple times.
+   * @param target node to change listeners on
+   * @param addEvent is this an 'addEvent' or 'removeEvent' change
+   * @param type event type requested to change
+   * @param index number in the listeners array this event corresponds to.
+   */
+  processListenerChange_(target: RenderableElement, addEvent: boolean, type: string, index: number): void {
+    let changeEventSubscribed: boolean = target.onchange !== null;
+    const shouldTrack: boolean = shouldTrackChanges(target as HTMLElement);
+    const isChangeEvent = type === 'change';
+
+    if (addEvent) {
+      if (isChangeEvent) {
+        changeEventSubscribed = true;
+        target.onchange = null;
+      }
+      (target as HTMLElement).addEventListener(type, (this.knownListeners_[index] = eventHandler(this.workerContext_, target._index_)));
+    } else {
+      if (isChangeEvent) {
+        changeEventSubscribed = false;
+      }
+      (target as HTMLElement).removeEventListener(type, this.knownListeners_[index]);
+    }
+    if (shouldTrack && !changeEventSubscribed) {
+      applyDefaultChangeListener(this.workerContext_, target as RenderableElement);
+    }
+  }
+}
 
 /**
  * Instead of a whitelist of elements that need their value tracked, use the existence
@@ -39,8 +102,8 @@ const shouldTrackChanges = (node: HTMLElement): boolean => node && 'value' in no
  * @param worker whom to dispatch value toward.
  * @param node node to listen to value changes on.
  */
-export const applyDefaultChangeListener = (worker: Worker, node: RenderableElement): void => {
-  shouldTrackChanges(node as HTMLElement) && node.onchange === null && (node.onchange = () => fireValueChange(worker, node));
+const applyDefaultChangeListener = (workerContext: WorkerContext, node: RenderableElement): void => {
+  shouldTrackChanges(node as HTMLElement) && node.onchange === null && (node.onchange = () => fireValueChange(workerContext, node));
 };
 
 /**
@@ -48,8 +111,8 @@ export const applyDefaultChangeListener = (worker: Worker, node: RenderableEleme
  * @param worker whom to dispatch value toward.
  * @param node where to get the value from.
  */
-const fireValueChange = (worker: Worker, node: RenderableElement): void => {
-  messageToWorker(worker, {
+const fireValueChange = (workerContext: WorkerContext, node: RenderableElement): void => {
+  workerContext.messageToWorker({
     [TransferrableKeys.type]: MessageType.SYNC,
     [TransferrableKeys.sync]: {
       [TransferrableKeys.index]: node._index_,
@@ -64,11 +127,11 @@ const fireValueChange = (worker: Worker, node: RenderableElement): void => {
  * @param index node index the event comes from (used to dispatchEvent in worker thread).
  * @return eventHandler function consuming event and dispatching to worker thread
  */
-const eventHandler = (worker: Worker, index: number) => (event: Event | KeyboardEvent): void => {
+const eventHandler = (workerContext: WorkerContext, index: number) => (event: Event | KeyboardEvent): void => {
   if (shouldTrackChanges(event.currentTarget as HTMLElement)) {
-    fireValueChange(worker, event.currentTarget as RenderableElement);
+    fireValueChange(workerContext, event.currentTarget as RenderableElement);
   }
-  messageToWorker(worker, {
+  workerContext.messageToWorker({
     [TransferrableKeys.type]: MessageType.EVENT,
     [TransferrableKeys.event]: {
       [TransferrableKeys.index]: index,
@@ -93,56 +156,3 @@ const eventHandler = (worker: Worker, index: number) => (event: Event | Keyboard
     },
   });
 };
-
-/**
- * If the worker requests to add an event listener to 'change' for something the foreground thread is already listening to,
- * ensure that only a single 'change' event is attached to prevent sending values multiple times.
- * @param worker worker issuing listener changes
- * @param target node to change listeners on
- * @param addEvent is this an 'addEvent' or 'removeEvent' change
- * @param type event type requested to change
- * @param index number in the listeners array this event corresponds to.
- */
-function processListenerChange(worker: Worker, target: RenderableElement, addEvent: boolean, type: string, index: number): void {
-  let changeEventSubscribed: boolean = target.onchange !== null;
-  const shouldTrack: boolean = shouldTrackChanges(target as HTMLElement);
-  const isChangeEvent = type === 'change';
-
-  if (addEvent) {
-    if (isChangeEvent) {
-      changeEventSubscribed = true;
-      target.onchange = null;
-    }
-    (target as HTMLElement).addEventListener(type, (KNOWN_LISTENERS[index] = eventHandler(worker, target._index_)));
-  } else {
-    if (isChangeEvent) {
-      changeEventSubscribed = false;
-    }
-    (target as HTMLElement).removeEventListener(type, KNOWN_LISTENERS[index]);
-  }
-  if (shouldTrack && !changeEventSubscribed) {
-    applyDefaultChangeListener(worker, target as RenderableElement);
-  }
-}
-
-/**
- * Process event subscription changes transfered from worker thread to main thread.
- * @param worker whom to dispatch events toward.
- * @param mutation mutation record containing commands to execute.
- */
-export function process(worker: Worker, mutation: TransferrableMutationRecord): void {
-  const nodeId = mutation[TransferrableKeys.target];
-  const target = getNode(nodeId);
-
-  if (!target) {
-    console.error('getNode() yields a null value. Node id (' + nodeId + ') was not found.');
-    return;
-  }
-
-  (mutation[TransferrableKeys.removedEvents] || []).forEach(eventSub =>
-    processListenerChange(worker, target, false, getString(eventSub[TransferrableKeys.type]), eventSub[TransferrableKeys.index]),
-  );
-  (mutation[TransferrableKeys.addedEvents] || []).forEach(eventSub =>
-    processListenerChange(worker, target, true, getString(eventSub[TransferrableKeys.type]), eventSub[TransferrableKeys.index]),
-  );
-}

--- a/src/main-thread/debugging.ts
+++ b/src/main-thread/debugging.ts
@@ -45,12 +45,12 @@ const MUTATION_RECORD_TYPE_REVERSE_MAPPING = {
 };
 
 export class DebuggingContext {
-  strings_: Strings;
-  nodeContext_: NodeContext;
+  private strings: Strings;
+  private nodeContext: NodeContext;
 
   constructor(strings: Strings, nodeContext: NodeContext) {
-    this.strings_ = strings;
-    this.nodeContext_ = nodeContext;
+    this.strings = strings;
+    this.nodeContext = nodeContext;
   }
 
   /**
@@ -71,7 +71,7 @@ export class DebuggingContext {
       const mutations = data[TransferrableKeys.mutations];
       const mutate: any = {
         type: data[TransferrableKeys.type] === MessageType.MUTATE ? 'MUTATE' : 'HYDRATE',
-        mutations: mutations.map(n => this.readableTransferrableMutationRecord_(n)),
+        mutations: mutations.map(n => this.readableTransferrableMutationRecord(n)),
         // Omit 'strings' key.
       };
       // TODO(choumx): Like 'strings', I'm not sure 'nodes' is actually useful.
@@ -91,18 +91,18 @@ export class DebuggingContext {
       const event = message[TransferrableKeys.event];
       return {
         type: 'EVENT',
-        event: readableTransferrableEvent(this.nodeContext_, event),
+        event: readableTransferrableEvent(this.nodeContext, event),
       };
     } else if (isValueSync(message)) {
       const sync = message[TransferrableKeys.sync];
       return {
         type: 'SYNC',
-        sync: readableTransferrableSyncValue(this.nodeContext_, sync),
+        sync: readableTransferrableSyncValue(this.nodeContext, sync),
       };
     } else if (isBoundingClientRect(message)) {
       return {
         type: 'GET_BOUNDING_CLIENT_RECT',
-        target: readableTransferredNode(this.nodeContext_, message[TransferrableKeys.target]),
+        target: readableTransferredNode(this.nodeContext, message[TransferrableKeys.target]),
       };
     } else {
       return 'Unrecognized MessageToWorker type: ' + message[TransferrableKeys.type];
@@ -112,20 +112,20 @@ export class DebuggingContext {
   /**
    * @param r
    */
-  readableTransferrableMutationRecord_(r: TransferrableMutationRecord): Object {
+  private readableTransferrableMutationRecord(r: TransferrableMutationRecord): Object {
     const target = r[TransferrableKeys.target];
 
     const out: any = {
       type: MUTATION_RECORD_TYPE_REVERSE_MAPPING[r[TransferrableKeys.type]],
-      target: this.nodeContext_.getNode(target) || target,
+      target: this.nodeContext.getNode(target) || target,
     };
     const added = r[TransferrableKeys.addedNodes];
     if (added) {
-      out['addedNodes'] = added.map(n => readableTransferredNode(this.nodeContext_, n));
+      out['addedNodes'] = added.map(n => readableTransferredNode(this.nodeContext, n));
     }
     const removed = r[TransferrableKeys.removedNodes];
     if (removed) {
-      out['removedNodes'] = removed.map(n => readableTransferredNode(this.nodeContext_, n));
+      out['removedNodes'] = removed.map(n => readableTransferredNode(this.nodeContext, n));
     }
     const previousSibling = r[TransferrableKeys.previousSibling];
     if (previousSibling) {
@@ -137,7 +137,7 @@ export class DebuggingContext {
     }
     const attributeName = r[TransferrableKeys.attributeName];
     if (attributeName !== undefined) {
-      out['attributeName'] = this.strings_.get(attributeName);
+      out['attributeName'] = this.strings.get(attributeName);
     }
     const attributeNamespace = r[TransferrableKeys.attributeNamespace];
     if (attributeNamespace !== undefined) {
@@ -149,11 +149,11 @@ export class DebuggingContext {
     }
     const value = r[TransferrableKeys.value];
     if (value !== undefined) {
-      out['value'] = this.strings_.get(value);
+      out['value'] = this.strings.get(value);
     }
     const oldValue = r[TransferrableKeys.oldValue];
     if (oldValue !== undefined) {
-      out['oldValue'] = this.strings_.get(oldValue);
+      out['oldValue'] = this.strings.get(oldValue);
     }
     const addedEvents = r[TransferrableKeys.addedEvents];
     if (addedEvents !== undefined) {

--- a/src/main-thread/index.safe.ts
+++ b/src/main-thread/index.safe.ts
@@ -17,49 +17,18 @@
 import { DOMPurifySanitizer } from './DOMPurifySanitizer';
 import { WorkerCallbacks } from './callbacks';
 import { fetchAndInstall, install } from './install';
-import { readableHydrateableNodeFromElement, readableMessageFromWorker, readableMessageToWorker } from './debugging';
 
 /** Users can import this and configure the sanitizer with custom DOMPurify hooks, etc. */
 export const sanitizer = new DOMPurifySanitizer();
-
-/** Users can import this and set callback functions to add logging on worker messages, etc. */
-export const callbacks: WorkerCallbacks = {};
-
-// Wrapper around `callbacks` to ensure that debugging.ts isn't bundled into other entry points.
-const wrappedCallbacks: WorkerCallbacks = {
-  onCreateWorker: initialDOM => {
-    if (callbacks.onCreateWorker) {
-      const readable = readableHydrateableNodeFromElement(initialDOM);
-      callbacks.onCreateWorker(readable as any);
-    }
-  },
-  onHydration: () => {
-    if (callbacks.onHydration) {
-      callbacks.onHydration();
-    }
-  },
-  onSendMessage: message => {
-    if (callbacks.onSendMessage) {
-      const readable = readableMessageToWorker(message);
-      callbacks.onSendMessage(readable as any);
-    }
-  },
-  onReceiveMessage: message => {
-    if (callbacks.onReceiveMessage) {
-      const readable = readableMessageFromWorker(message);
-      callbacks.onReceiveMessage(readable as any);
-    }
-  },
-};
 
 /**
  * @param baseElement
  * @param workerDOMUrl
  */
-export function upgradeElement(baseElement: Element, workerDOMUrl: string): void {
+export function upgradeElement(baseElement: Element, workerDOMUrl: string, callbacks?: WorkerCallbacks, debug?: boolean): void {
   const authorURL = baseElement.getAttribute('src');
   if (authorURL) {
-    fetchAndInstall(baseElement as HTMLElement, authorURL, workerDOMUrl, wrappedCallbacks, sanitizer);
+    fetchAndInstall(baseElement as HTMLElement, authorURL, workerDOMUrl, callbacks, sanitizer, debug);
   }
 }
 
@@ -68,6 +37,6 @@ export function upgradeElement(baseElement: Element, workerDOMUrl: string): void
  * @param baseElement
  * @param fetchPromise Promise that resolves with a tuple containing the worker script, author script, and author script URL.
  */
-export function upgrade(baseElement: Element, fetchPromise: Promise<[string, string, string]>): void {
-  install(fetchPromise, baseElement as HTMLElement, wrappedCallbacks, sanitizer);
+export function upgrade(baseElement: Element, fetchPromise: Promise<[string, string, string]>, callbacks?: WorkerCallbacks, debug?: boolean): void {
+  install(fetchPromise, baseElement as HTMLElement, callbacks, sanitizer, debug);
 }

--- a/src/main-thread/install.ts
+++ b/src/main-thread/install.ts
@@ -16,7 +16,7 @@
 
 import { DebuggingContext } from './debugging';
 import { MutationFromWorker, MessageType, MessageFromWorker } from '../transfer/Messages';
-import { MutatorContext } from './mutator';
+import { MutatorProcessor } from './mutator';
 import { NodeContext } from './nodes';
 import { Strings } from './strings';
 import { TransferrableKeys } from '../transfer/TransferrableKeys';
@@ -76,7 +76,7 @@ export function install(
       const workerContext = new WorkerContext(baseElement, workerDOMScript, authorScript, authorScriptURL, callbacks);
       const worker = workerContext.getWorker();
       setPhase(Phases.Hydrating);
-      const mutatorContext = new MutatorContext(strings, nodeContext, workerContext, sanitizer);
+      const mutatorContext = new MutatorProcessor(strings, nodeContext, workerContext, sanitizer);
       worker.onmessage = (message: MessageFromWorker) => {
         const { data } = message;
         const type = data[TransferrableKeys.type];

--- a/src/main-thread/install.ts
+++ b/src/main-thread/install.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import { createWorker } from './worker';
+import { DebuggingContext } from './debugging';
 import { MutationFromWorker, MessageType, MessageFromWorker } from '../transfer/Messages';
-import { prepare as prepareNodes } from './nodes';
-import { prepareMutate, mutate } from './mutator';
-import { set as setPhase, Phases } from '../transfer/phase';
+import { MutatorContext } from './mutator';
+import { NodeContext } from './nodes';
+import { Strings } from './strings';
 import { TransferrableKeys } from '../transfer/TransferrableKeys';
 import { WorkerCallbacks } from './callbacks';
+import { WorkerContext } from './worker';
+import { set as setPhase, Phases } from '../transfer/phase';
 
 const ALLOWABLE_MESSAGE_TYPES = [MessageType.MUTATE, MessageType.HYDRATE];
 
@@ -30,6 +32,7 @@ const ALLOWABLE_MESSAGE_TYPES = [MessageType.MUTATE, MessageType.HYDRATE];
  * @param workerDOMURL
  * @param callbacks
  * @param sanitizer
+ * @param debug
  */
 export function fetchAndInstall(
   baseElement: HTMLElement,
@@ -37,6 +40,7 @@ export function fetchAndInstall(
   workerDOMURL: string,
   callbacks?: WorkerCallbacks,
   sanitizer?: Sanitizer,
+  debug?: boolean,
 ): void {
   const fetchPromise = Promise.all([
     // TODO(KB): Fetch Polyfill for IE11.
@@ -44,7 +48,7 @@ export function fetchAndInstall(
     fetch(authorScriptURL).then(response => response.text()),
     Promise.resolve(authorScriptURL),
   ]);
-  install(fetchPromise, baseElement, callbacks, sanitizer);
+  install(fetchPromise, baseElement, callbacks, sanitizer, debug);
 }
 
 /**
@@ -52,19 +56,27 @@ export function fetchAndInstall(
  * @param baseElement
  * @param callbacks
  * @param sanitizer
+ * @param debug
  */
 export function install(
   fetchPromise: Promise<[string, string, string]>,
   baseElement: HTMLElement,
   callbacks?: WorkerCallbacks,
   sanitizer?: Sanitizer,
+  debug?: boolean,
 ): void {
-  prepareNodes(baseElement);
+  const strings = new Strings();
+  const nodeContext = new NodeContext(strings, baseElement);
+  if (debug) {
+    const debuggingContext = new DebuggingContext(strings, nodeContext);
+    callbacks = wrapCallbacks(debuggingContext, callbacks);
+  }
   fetchPromise.then(([workerDOMScript, authorScript, authorScriptURL]) => {
     if (workerDOMScript && authorScript && authorScriptURL) {
-      const worker = createWorker(baseElement, workerDOMScript, authorScript, authorScriptURL, callbacks);
+      const workerContext = new WorkerContext(baseElement, workerDOMScript, authorScript, authorScriptURL, callbacks);
+      const worker = workerContext.getWorker();
       setPhase(Phases.Hydrating);
-      prepareMutate(worker, sanitizer);
+      const mutatorContext = new MutatorContext(strings, nodeContext, workerContext, sanitizer);
       worker.onmessage = (message: MessageFromWorker) => {
         const { data } = message;
         const type = data[TransferrableKeys.type];
@@ -73,7 +85,7 @@ export function install(
         }
         // TODO(KB): Hydration has special rules limiting the types of allowed mutations.
         // Re-introduce Hydration and add a specialized handler.
-        mutate(
+        mutatorContext.mutate(
           (data as MutationFromWorker)[TransferrableKeys.nodes],
           (data as MutationFromWorker)[TransferrableKeys.strings],
           (data as MutationFromWorker)[TransferrableKeys.mutations],
@@ -91,4 +103,34 @@ export function install(
     }
     return null;
   });
+}
+
+// TODO(dvoytenko): reverse the dependency direction so that we can remove
+// debugging.ts from other entry points.
+function wrapCallbacks(debuggingContext: DebuggingContext, callbacks?: WorkerCallbacks): WorkerCallbacks {
+  return {
+    onCreateWorker(initialDOM) {
+      if (callbacks && callbacks.onCreateWorker) {
+        const readable = debuggingContext.readableHydrateableNodeFromElement(initialDOM);
+        callbacks.onCreateWorker(readable as any);
+      }
+    },
+    onHydration() {
+      if (callbacks && callbacks.onHydration) {
+        callbacks.onHydration();
+      }
+    },
+    onSendMessage(message) {
+      if (callbacks && callbacks.onSendMessage) {
+        const readable = debuggingContext.readableMessageToWorker(message);
+        callbacks.onSendMessage(readable as any);
+      }
+    },
+    onReceiveMessage(message) {
+      if (callbacks && callbacks.onReceiveMessage) {
+        const readable = debuggingContext.readableMessageFromWorker(message);
+        callbacks.onReceiveMessage(readable as any);
+      }
+    },
+  };
 }

--- a/src/main-thread/mutator.ts
+++ b/src/main-thread/mutator.ts
@@ -31,8 +31,6 @@ export class MutatorContext {
   pendingMutations_: boolean;
   workerContext_: WorkerContext;
   sanitizer_: Sanitizer | undefined;
-  eventSubscriptionProcessor_: EventSubscriptionProcessor;
-  boundingClientRectProcessor_: BoundingClientRectProcessor;
   mutators_: {
     [key: number]: (mutation: TransferrableMutationRecord, target: Node) => void;
   };
@@ -51,16 +49,16 @@ export class MutatorContext {
     this.mutationQueue_ = [];
     this.pendingMutations_ = false;
 
-    this.eventSubscriptionProcessor_ = new EventSubscriptionProcessor(strings, nodeContext, workerContext);
-    this.boundingClientRectProcessor_ = new BoundingClientRectProcessor(nodeContext, workerContext);
+    const eventSubscriptionProcessor = new EventSubscriptionProcessor(strings, nodeContext, workerContext);
+    const boundingClientRectProcessor = new BoundingClientRectProcessor(nodeContext, workerContext);
 
     this.mutators_ = {
       [MutationRecordType.CHILD_LIST]: this.mutateChildList_.bind(this),
       [MutationRecordType.ATTRIBUTES]: this.mutateAttributes_.bind(this),
       [MutationRecordType.CHARACTER_DATA]: this.mutateCharacterData_.bind(this),
       [MutationRecordType.PROPERTIES]: this.mutateProperties_.bind(this),
-      [MutationRecordType.EVENT_SUBSCRIPTION]: this.eventSubscriptionProcessor_.process.bind(this.eventSubscriptionProcessor_),
-      [MutationRecordType.GET_BOUNDING_CLIENT_RECT]: this.boundingClientRectProcessor_.process.bind(this.boundingClientRectProcessor_),
+      [MutationRecordType.EVENT_SUBSCRIPTION]: eventSubscriptionProcessor.process.bind(eventSubscriptionProcessor),
+      [MutationRecordType.GET_BOUNDING_CLIENT_RECT]: boundingClientRectProcessor.process.bind(boundingClientRectProcessor),
     };
   }
 

--- a/src/main-thread/mutator.ts
+++ b/src/main-thread/mutator.ts
@@ -24,14 +24,13 @@ import { WorkerContext } from './worker';
 import { EventSubscriptionProcessor } from './commands/event-subscription';
 import { BoundingClientRectProcessor } from './commands/bounding-client-rect';
 
-export class MutatorContext {
-  strings_: Strings;
-  nodeContext_: NodeContext;
-  mutationQueue_: Array<TransferrableMutationRecord>;
-  pendingMutations_: boolean;
-  workerContext_: WorkerContext;
-  sanitizer_: Sanitizer | undefined;
-  mutators_: {
+export class MutatorProcessor {
+  private strings: Strings;
+  private nodeContext: NodeContext;
+  private mutationQueue: Array<TransferrableMutationRecord>;
+  private pendingMutations: boolean;
+  private sanitizer: Sanitizer | undefined;
+  private mutators: {
     [key: number]: (mutation: TransferrableMutationRecord, target: Node) => void;
   };
 
@@ -42,21 +41,20 @@ export class MutatorContext {
    * @param passedSanitizer Sanitizer to apply to content if needed.
    */
   constructor(strings: Strings, nodeContext: NodeContext, workerContext: WorkerContext, passedSanitizer?: Sanitizer) {
-    this.strings_ = strings;
-    this.nodeContext_ = nodeContext;
-    this.workerContext_ = workerContext;
-    this.sanitizer_ = passedSanitizer;
-    this.mutationQueue_ = [];
-    this.pendingMutations_ = false;
+    this.strings = strings;
+    this.nodeContext = nodeContext;
+    this.sanitizer = passedSanitizer;
+    this.mutationQueue = [];
+    this.pendingMutations = false;
 
     const eventSubscriptionProcessor = new EventSubscriptionProcessor(strings, nodeContext, workerContext);
     const boundingClientRectProcessor = new BoundingClientRectProcessor(nodeContext, workerContext);
 
-    this.mutators_ = {
-      [MutationRecordType.CHILD_LIST]: this.mutateChildList_.bind(this),
-      [MutationRecordType.ATTRIBUTES]: this.mutateAttributes_.bind(this),
-      [MutationRecordType.CHARACTER_DATA]: this.mutateCharacterData_.bind(this),
-      [MutationRecordType.PROPERTIES]: this.mutateProperties_.bind(this),
+    this.mutators = {
+      [MutationRecordType.CHILD_LIST]: this.mutateChildList.bind(this),
+      [MutationRecordType.ATTRIBUTES]: this.mutateAttributes.bind(this),
+      [MutationRecordType.CHARACTER_DATA]: this.mutateCharacterData.bind(this),
+      [MutationRecordType.PROPERTIES]: this.mutateProperties.bind(this),
       [MutationRecordType.EVENT_SUBSCRIPTION]: eventSubscriptionProcessor.process.bind(eventSubscriptionProcessor),
       [MutationRecordType.GET_BOUNDING_CLIENT_RECT]: boundingClientRectProcessor.process.bind(boundingClientRectProcessor),
     };
@@ -75,12 +73,12 @@ export class MutatorContext {
     //   return;
     // }
     // this.lastGestureTime = lastGestureTime;
-    this.strings_.storeValues(stringValues);
-    nodes.forEach(node => this.nodeContext_.createNode(node, this.sanitizer_));
-    this.mutationQueue_ = this.mutationQueue_.concat(mutations);
-    if (!this.pendingMutations_) {
-      this.pendingMutations_ = true;
-      requestAnimationFrame(this.syncFlush_.bind(this));
+    this.strings.storeValues(stringValues);
+    nodes.forEach(node => this.nodeContext.createNode(node, this.sanitizer));
+    this.mutationQueue = this.mutationQueue.concat(mutations);
+    if (!this.pendingMutations) {
+      this.pendingMutations = true;
+      requestAnimationFrame(this.syncFlush.bind(this));
     }
   }
 
@@ -90,24 +88,24 @@ export class MutatorContext {
    *
    * Investigations in using asyncFlush to resolve are worth considering.
    */
-  syncFlush_(): void {
-    this.mutationQueue_.forEach(mutation => {
+  private syncFlush(): void {
+    this.mutationQueue.forEach(mutation => {
       const nodeId = mutation[TransferrableKeys.target];
-      const node = this.nodeContext_.getNode(nodeId);
+      const node = this.nodeContext.getNode(nodeId);
       if (!node) {
         console.error('getNode() yields a null value. Node id (' + nodeId + ') was not found.');
         return;
       }
-      this.mutators_[mutation[TransferrableKeys.type]](mutation, node);
+      this.mutators[mutation[TransferrableKeys.type]](mutation, node);
     });
-    this.mutationQueue_ = [];
-    this.pendingMutations_ = false;
+    this.mutationQueue = [];
+    this.pendingMutations = false;
   }
 
-  mutateChildList_(mutation: TransferrableMutationRecord, target: HTMLElement) {
+  private mutateChildList(mutation: TransferrableMutationRecord, target: HTMLElement) {
     (mutation[TransferrableKeys.removedNodes] || []).forEach(nodeReference => {
       const nodeId = nodeReference[TransferrableKeys.index];
-      const node = this.nodeContext_.getNode(nodeId);
+      const node = this.nodeContext.getNode(nodeId);
       if (!node) {
         console.error('getNode() yields a null value. Node id (' + nodeId + ') was not found.');
         return;
@@ -120,18 +118,18 @@ export class MutatorContext {
     if (addedNodes) {
       addedNodes.forEach(node => {
         let newChild = null;
-        newChild = this.nodeContext_.getNode(node[TransferrableKeys.index]);
+        newChild = this.nodeContext.getNode(node[TransferrableKeys.index]);
 
         if (!newChild) {
           // Transferred nodes that are not stored were previously removed by the sanitizer.
           if (node[TransferrableKeys.transferred]) {
             return;
           } else {
-            newChild = this.nodeContext_.createNode(node as TransferrableNode, this.sanitizer_);
+            newChild = this.nodeContext.createNode(node as TransferrableNode, this.sanitizer);
           }
         }
         if (newChild) {
-          target.insertBefore(newChild, (nextSibling && this.nodeContext_.getNode(nextSibling[TransferrableKeys.index])) || null);
+          target.insertBefore(newChild, (nextSibling && this.nodeContext.getNode(nextSibling[TransferrableKeys.index])) || null);
         } else {
           // TODO(choumx): Inform worker that sanitizer removed newChild.
         }
@@ -139,15 +137,15 @@ export class MutatorContext {
     }
   }
 
-  mutateAttributes_(mutation: TransferrableMutationRecord, target: HTMLElement | SVGElement) {
+  private mutateAttributes(mutation: TransferrableMutationRecord, target: HTMLElement | SVGElement) {
     const attributeName =
-      mutation[TransferrableKeys.attributeName] !== undefined ? this.strings_.get(mutation[TransferrableKeys.attributeName] as number) : null;
-    const value = mutation[TransferrableKeys.value] !== undefined ? this.strings_.get(mutation[TransferrableKeys.value] as number) : null;
+      mutation[TransferrableKeys.attributeName] !== undefined ? this.strings.get(mutation[TransferrableKeys.attributeName] as number) : null;
+    const value = mutation[TransferrableKeys.value] !== undefined ? this.strings.get(mutation[TransferrableKeys.value] as number) : null;
     if (attributeName != null) {
       if (value == null) {
         target.removeAttribute(attributeName);
       } else {
-        if (!this.sanitizer_ || this.sanitizer_.validAttribute(target.nodeName, attributeName, value)) {
+        if (!this.sanitizer || this.sanitizer.validAttribute(target.nodeName, attributeName, value)) {
           target.setAttribute(attributeName, value);
         } else {
           // TODO(choumx): Inform worker that sanitizer ignored unsafe attribute value change.
@@ -156,21 +154,21 @@ export class MutatorContext {
     }
   }
 
-  mutateCharacterData_(mutation: TransferrableMutationRecord, target: CharacterData) {
+  private mutateCharacterData(mutation: TransferrableMutationRecord, target: CharacterData) {
     const value = mutation[TransferrableKeys.value];
     if (value) {
       // Sanitization not necessary for textContent.
-      target.textContent = this.strings_.get(value);
+      target.textContent = this.strings.get(value);
     }
   }
 
-  mutateProperties_(mutation: TransferrableMutationRecord, target: RenderableElement) {
+  private mutateProperties(mutation: TransferrableMutationRecord, target: RenderableElement) {
     const propertyName =
-      mutation[TransferrableKeys.propertyName] !== undefined ? this.strings_.get(mutation[TransferrableKeys.propertyName] as number) : null;
-    const value = mutation[TransferrableKeys.value] !== undefined ? this.strings_.get(mutation[TransferrableKeys.value] as number) : null;
+      mutation[TransferrableKeys.propertyName] !== undefined ? this.strings.get(mutation[TransferrableKeys.propertyName] as number) : null;
+    const value = mutation[TransferrableKeys.value] !== undefined ? this.strings.get(mutation[TransferrableKeys.value] as number) : null;
     if (propertyName && value != null) {
       const stringValue = String(value);
-      if (!this.sanitizer_ || this.sanitizer_.validProperty(target.nodeName, propertyName, stringValue)) {
+      if (!this.sanitizer || this.sanitizer.validProperty(target.nodeName, propertyName, stringValue)) {
         // TODO(choumx, #122): Proper support for non-string property mutations.
         const isBooleanProperty = propertyName == 'checked';
         target[propertyName] = isBooleanProperty ? value === 'true' : value;

--- a/src/main-thread/nodes.ts
+++ b/src/main-thread/nodes.ts
@@ -16,105 +16,117 @@
 
 import { TransferrableNode, NodeType } from '../transfer/TransferrableNodes';
 import { TransferrableKeys } from '../transfer/TransferrableKeys';
-import { get as getString } from './strings';
+import { Strings } from './strings';
 
-let count: number = 2;
-let NODES: Map<number, Node>;
-let BASE_ELEMENT: HTMLElement;
+export class NodeContext {
+  baseElement_: HTMLElement;
+  strings_: Strings;
+  count_: number;
+  nodes_: Map<number, Node>;
 
-/**
- * Called when initializing a Worker, ensures the nodes in baseElement are known
- * for transmission into the Worker and future mutation events from the Worker.
- * @param baseElement Element that will be controlled by a Worker
- */
-export function prepare(baseElement: Element): void {
-  // The NODES map is populated with two default values pointing to baseElement.
-  // These are [document, document.body] from the worker.
-  NODES = new Map([[1, baseElement], [2, baseElement]]);
-  BASE_ELEMENT = baseElement as HTMLElement;
-  // To ensure a lookup works correctly from baseElement
-  // add an index equal to the background thread document.body.
-  baseElement._index_ = 2;
-  // Lastly, it's important while initializing the document that we store
-  // the default nodes present in the server rendered document.
-  baseElement.childNodes.forEach(storeNodes);
-}
+  /**
+   * Called when initializing a Worker, ensures the nodes in baseElement are
+   * known for transmission into the Worker and future mutation events from the
+   * Worker.
+   * @param baseElement Element that will be controlled by a Worker
+   */
+  constructor(strings: Strings, baseElement: Element) {
+    this.count_ = 2;
+    this.strings_ = strings;
 
-/**
- * Store the requested node and all of its children.
- * @param node node to store.
- */
-function storeNodes(node: Node): void {
-  storeNode(node, ++count);
-  node.childNodes.forEach(storeNodes);
-}
+    // The nodes_ map is populated with two default values pointing to
+    // baseElement.
+    // These are [document, document.body] from the worker.
+    this.nodes_ = new Map([[1, baseElement], [2, baseElement]]);
+    this.baseElement_ = baseElement as HTMLElement;
+    // To ensure a lookup works correctly from baseElement
+    // add an index equal to the background thread document.body.
+    baseElement._index_ = 2;
+    // Lastly, it's important while initializing the document that we store
+    // the default nodes present in the server rendered document.
+    baseElement.childNodes.forEach(n => this.storeNodes_(n));
+  }
 
-/**
- * Create a real DOM Node from a skeleton Object (`{ nodeType, nodeName, attributes, children, data }`)
- * @example <caption>Text node</caption>
- *   createNode({ nodeType:3, data:'foo' })
- * @example <caption>Element node</caption>
- *   createNode({ nodeType:1, nodeName:'div', attributes:[{ name:'a', value:'b' }], childNodes:[ ... ] })
- */
-export function createNode(skeleton: TransferrableNode, sanitizer?: Sanitizer): Node | null {
-  let node: Node;
-  if (skeleton[TransferrableKeys.nodeType] === NodeType.TEXT_NODE) {
-    node = document.createTextNode(getString(skeleton[TransferrableKeys.textContent] as number));
-  } else if (skeleton[TransferrableKeys.nodeType] === NodeType.DOCUMENT_FRAGMENT_NODE) {
-    node = document.createDocumentFragment();
-  } else {
-    const namespace =
-      skeleton[TransferrableKeys.namespaceURI] !== undefined ? getString(skeleton[TransferrableKeys.namespaceURI] as number) : undefined;
-    const nodeName = getString(skeleton[TransferrableKeys.nodeName]);
-    node = namespace ? document.createElementNS(namespace, nodeName) : document.createElement(nodeName);
+  getBaseElement(): HTMLElement {
+    return this.baseElement_;
+  }
 
-    // TODO(KB): Restore Properties
-    // skeleton.properties.forEach(property => {
-    //   node[`${property.name}`] = property.value;
-    // });
-    // ((skeleton as TransferrableElement)[TransferrableKeys.childNodes] || []).forEach(childNode => {
-    //   if (childNode[TransferrableKeys.transferred] === NumericBoolean.FALSE) {
-    //     node.appendChild(createNode(childNode as TransferrableNode));
-    //   }
-    // });
+  /**
+   * Create a real DOM Node from a skeleton Object (`{ nodeType, nodeName, attributes, children, data }`)
+   * @example <caption>Text node</caption>
+   *   nodeContext.createNode({ nodeType:3, data:'foo' })
+   * @example <caption>Element node</caption>
+   *   nodeContext.createNode({ nodeType:1, nodeName:'div', attributes:[{ name:'a', value:'b' }], childNodes:[ ... ] })
+   */
+  createNode(skeleton: TransferrableNode, sanitizer?: Sanitizer): Node | null {
+    let node: Node;
+    if (skeleton[TransferrableKeys.nodeType] === NodeType.TEXT_NODE) {
+      node = document.createTextNode(this.strings_.get(skeleton[TransferrableKeys.textContent] as number));
+    } else if (skeleton[TransferrableKeys.nodeType] === NodeType.DOCUMENT_FRAGMENT_NODE) {
+      node = document.createDocumentFragment();
+    } else {
+      const namespace =
+        skeleton[TransferrableKeys.namespaceURI] !== undefined ? this.strings_.get(skeleton[TransferrableKeys.namespaceURI] as number) : undefined;
+      const nodeName = this.strings_.get(skeleton[TransferrableKeys.nodeName]);
+      node = namespace ? document.createElementNS(namespace, nodeName) : document.createElement(nodeName);
 
-    // If `node` is removed by the sanitizer, don't store it and return null.
-    if (sanitizer && !sanitizer.sanitize(node)) {
-      return null;
+      // TODO(KB): Restore Properties
+      // skeleton.properties.forEach(property => {
+      //   node[`${property.name}`] = property.value;
+      // });
+      // ((skeleton as TransferrableElement)[TransferrableKeys.childNodes] || []).forEach(childNode => {
+      //   if (childNode[TransferrableKeys.transferred] === NumericBoolean.FALSE) {
+      //     node.appendChild(this.createNode(childNode as TransferrableNode));
+      //   }
+      // });
+
+      // If `node` is removed by the sanitizer, don't store it and return null.
+      if (sanitizer && !sanitizer.sanitize(node)) {
+        return null;
+      }
     }
+
+    this.storeNode_(node, skeleton[TransferrableKeys.index]);
+    return node;
   }
 
-  storeNode(node, skeleton[TransferrableKeys.index]);
-  return node;
-}
+  /**
+   * Returns the real DOM Element corresponding to a serialized Element object.
+   * @param id
+   * @return RenderableElement | null
+   */
+  getNode(id: number): RenderableElement | null {
+    const node = this.nodes_.get(id);
 
-/**
- * Returns the real DOM Element corresponding to a serialized Element object.
- * @param id
- * @return RenderableElement | null
- */
-export function getNode(id: number): RenderableElement | null {
-  const node = NODES.get(id);
-
-  if (node && node.nodeName === 'BODY') {
-    // If the node requested is the "BODY"
-    // Then we return the base node this specific <amp-script> comes from.
-    // This encapsulates each <amp-script> node.
-    return BASE_ELEMENT as RenderableElement;
+    if (node && node.nodeName === 'BODY') {
+      // If the node requested is the "BODY"
+      // Then we return the base node this specific <amp-script> comes from.
+      // This encapsulates each <amp-script> node.
+      return this.baseElement_ as RenderableElement;
+    }
+    return node as RenderableElement;
   }
-  return node as RenderableElement;
-}
 
-/**
- * Establish link between DOM `node` and worker-generated identifier `id`.
- *
- * These _shouldn't_ collide between instances of <amp-script> since
- * each element creates it's own pool on both sides of the worker
- * communication bridge.
- * @param node
- * @param id
- */
-export function storeNode(node: Node, id: number): void {
-  (node as Node)._index_ = id;
-  NODES.set(id, node as Node);
+  /**
+   * Store the requested node and all of its children.
+   * @param node node to store.
+   */
+  storeNodes_(node: Node): void {
+    this.storeNode_(node, ++this.count_);
+    node.childNodes.forEach(n => this.storeNodes_(n));
+  }
+
+  /**
+   * Establish link between DOM `node` and worker-generated identifier `id`.
+   *
+   * These _shouldn't_ collide between instances of <amp-script> since
+   * each element creates it's own pool on both sides of the worker
+   * communication bridge.
+   * @param node
+   * @param id
+   */
+  storeNode_(node: Node, id: number): void {
+    (node as Node)._index_ = id;
+    this.nodes_.set(id, node as Node);
+  }
 }

--- a/src/main-thread/strings.ts
+++ b/src/main-thread/strings.ts
@@ -15,10 +15,10 @@
  */
 
 export class Strings {
-  strings_: Array<string>;
+  private strings: Array<string>;
 
   constructor() {
-    this.strings_ = [];
+    this.strings = [];
   }
 
   /**
@@ -27,7 +27,7 @@ export class Strings {
    * @returns string in map for the index.
    */
   get(index: number): string {
-    return this.strings_[index] || '';
+    return this.strings[index] || '';
   }
 
   /**
@@ -36,7 +36,7 @@ export class Strings {
    * @return location in map
    */
   store(value: string): void {
-    this.strings_.push(value);
+    this.strings.push(value);
   }
 
   /**

--- a/src/main-thread/strings.ts
+++ b/src/main-thread/strings.ts
@@ -14,22 +14,36 @@
  * limitations under the License.
  */
 
-const strings: Array<string> = [];
+export class Strings {
+  strings_: Array<string>;
 
-/**
- * Return a string for the specified index.
- * @param index string index to retrieve.
- * @returns string in map for the index.
- */
-export function get(index: number): string {
-  return strings[index] || '';
-}
+  constructor() {
+    this.strings_ = [];
+  }
 
-/**
- * Stores a string in mapping and returns the index of the location.
- * @param value string to store
- * @return location in map
- */
-export function store(value: string): void {
-  strings.push(value);
+  /**
+   * Return a string for the specified index.
+   * @param index string index to retrieve.
+   * @returns string in map for the index.
+   */
+  get(index: number): string {
+    return this.strings_[index] || '';
+  }
+
+  /**
+   * Stores a string in mapping and returns the index of the location.
+   * @param value string to store
+   * @return location in map
+   */
+  store(value: string): void {
+    this.strings_.push(value);
+  }
+
+  /**
+   * Stores a set of strings.
+   * @param values
+   */
+  storeValues(values: Array<string>): void {
+    values.forEach(this.store.bind(this));
+  }
 }

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -15,81 +15,80 @@
  */
 
 import { MessageToWorker } from '../transfer/Messages';
-import { createHydrateableRootNode } from './serialize';
 import { WorkerCallbacks } from './callbacks';
+import { createHydrateableRootNode } from './serialize';
 
-/**
- * Stored callbacks for the most recently created worker.
- * Note: This can be easily changed to a lookup table to support multiple workers.
- */
-let callbacks_: WorkerCallbacks | undefined;
+export class WorkerContext {
+  worker_: Worker;
 
-/**
- * Also stores `callbacks` in a global.
- * @param baseElement
- * @param workerDOMScript
- * @param authorScript
- * @param authorScriptURL
- */
-export function createWorker(
-  baseElement: HTMLElement,
-  workerDOMScript: string,
-  authorScript: string,
-  authorScriptURL: string,
-  callbacks?: WorkerCallbacks,
-): Worker {
-  callbacks_ = callbacks;
+  /**
+   * Stored callbacks for the most recently created worker.
+   * Note: This can be easily changed to a lookup table to support multiple workers.
+   */
+  callbacks_: WorkerCallbacks | undefined;
 
-  // TODO(KB): Minify this output during build process.
-  const keys: Array<string> = [];
-  const { skeleton, strings } = createHydrateableRootNode(baseElement);
-  for (const key in document.body.style) {
-    keys.push(key);
+  /**
+   * @param baseElement
+   * @param workerDOMScript
+   * @param authorScript
+   * @param authorScriptURL
+   */
+  constructor(baseElement: HTMLElement, workerDOMScript: string, authorScript: string, authorScriptURL: string, callbacks?: WorkerCallbacks) {
+    this.callbacks_ = callbacks;
+
+    // TODO(KB): Minify this output during build process.
+    const keys: Array<string> = [];
+    const { skeleton, strings } = createHydrateableRootNode(baseElement);
+    for (const key in document.body.style) {
+      keys.push(key);
+    }
+    const code = `
+      'use strict';
+      ${workerDOMScript}
+      (function() {
+        var self = this;
+        var window = this;
+        var document = this.document;
+        var localStorage = this.localStorage;
+        var location = this.location;
+        var defaultView = document.defaultView;
+        var Node = defaultView.Node;
+        var Text = defaultView.Text;
+        var Element = defaultView.Element;
+        var SVGElement = defaultView.SVGElement;
+        var Document = defaultView.Document;
+        var Event = defaultView.Event;
+        var MutationObserver = defaultView.MutationObserver;
+
+        function addEventListener(type, handler) {
+          return document.addEventListener(type, handler);
+        }
+        function removeEventListener(type, handler) {
+          return document.removeEventListener(type, handler);
+        }
+        this.consumeInitialDOM(document, ${JSON.stringify(strings)}, ${JSON.stringify(skeleton)});
+        this.appendKeys(${JSON.stringify(keys)});
+        document.observe();
+        ${authorScript}
+      }).call(WorkerThread.workerDOM);
+  //# sourceURL=${encodeURI(authorScriptURL)}`;
+    this.worker_ = new Worker(URL.createObjectURL(new Blob([code])));
+    if (callbacks && callbacks.onCreateWorker) {
+      callbacks.onCreateWorker(baseElement);
+    }
   }
-  const code = `
-    'use strict';
-    ${workerDOMScript}
-    (function() {
-      var self = this;
-      var window = this;
-      var document = this.document;
-      var localStorage = this.localStorage;
-      var location = this.location;
-      var defaultView = document.defaultView;
-      var Node = defaultView.Node;
-      var Text = defaultView.Text;
-      var Element = defaultView.Element;
-      var SVGElement = defaultView.SVGElement;
-      var Document = defaultView.Document;
-      var Event = defaultView.Event;
-      var MutationObserver = defaultView.MutationObserver;
 
-      function addEventListener(type, handler) {
-        return document.addEventListener(type, handler);
-      }
-      function removeEventListener(type, handler) {
-        return document.removeEventListener(type, handler);
-      }
-      this.consumeInitialDOM(document, ${JSON.stringify(strings)}, ${JSON.stringify(skeleton)});
-      this.appendKeys(${JSON.stringify(keys)});
-      document.observe();
-      ${authorScript}
-    }).call(WorkerThread.workerDOM);
-//# sourceURL=${encodeURI(authorScriptURL)}`;
-  const worker = new Worker(URL.createObjectURL(new Blob([code])));
-  if (callbacks && callbacks.onCreateWorker) {
-    callbacks.onCreateWorker(baseElement);
+  getWorker(): Worker {
+    return this.worker_;
   }
-  return worker;
-}
 
-/**
- * @param worker
- * @param message
- */
-export function messageToWorker(worker: Worker, message: MessageToWorker) {
-  if (callbacks_ && callbacks_.onSendMessage) {
-    callbacks_.onSendMessage(message);
+  /**
+   * @param message
+   */
+  messageToWorker(message: MessageToWorker) {
+    if (this.callbacks_ && this.callbacks_.onSendMessage) {
+      this.callbacks_.onSendMessage(message);
+    }
+    this.worker_.postMessage(message);
   }
-  worker.postMessage(message);
 }

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -19,13 +19,13 @@ import { WorkerCallbacks } from './callbacks';
 import { createHydrateableRootNode } from './serialize';
 
 export class WorkerContext {
-  worker_: Worker;
+  private worker: Worker;
 
   /**
    * Stored callbacks for the most recently created worker.
    * Note: This can be easily changed to a lookup table to support multiple workers.
    */
-  callbacks_: WorkerCallbacks | undefined;
+  private callbacks: WorkerCallbacks | undefined;
 
   /**
    * @param baseElement
@@ -34,7 +34,7 @@ export class WorkerContext {
    * @param authorScriptURL
    */
   constructor(baseElement: HTMLElement, workerDOMScript: string, authorScript: string, authorScriptURL: string, callbacks?: WorkerCallbacks) {
-    this.callbacks_ = callbacks;
+    this.callbacks = callbacks;
 
     // TODO(KB): Minify this output during build process.
     const keys: Array<string> = [];
@@ -72,23 +72,23 @@ export class WorkerContext {
         ${authorScript}
       }).call(WorkerThread.workerDOM);
   //# sourceURL=${encodeURI(authorScriptURL)}`;
-    this.worker_ = new Worker(URL.createObjectURL(new Blob([code])));
+    this.worker = new Worker(URL.createObjectURL(new Blob([code])));
     if (callbacks && callbacks.onCreateWorker) {
       callbacks.onCreateWorker(baseElement);
     }
   }
 
   getWorker(): Worker {
-    return this.worker_;
+    return this.worker;
   }
 
   /**
    * @param message
    */
   messageToWorker(message: MessageToWorker) {
-    if (this.callbacks_ && this.callbacks_.onSendMessage) {
-      this.callbacks_.onSendMessage(message);
+    if (this.callbacks && this.callbacks.onSendMessage) {
+      this.callbacks.onSendMessage(message);
     }
-    this.worker_.postMessage(message);
+    this.worker.postMessage(message);
   }
 }


### PR DESCRIPTION
Fixes: #297

Most of the main-thread code is now scoped per `baseElement` or `NodeContext`.

The one issue I haven't yet resolved - is treatment of `DebuggingContext` which currently bundled into main `install.ts` and adds about 0.6-0.7Kb.

/to @kristoferbaxter @choumx 