### PR TITLE
Avoid super.getter

### DIFF
--- a/src/worker-thread/dom/Element.ts
+++ b/src/worker-thread/dom/Element.ts
@@ -185,7 +185,7 @@ export class Element extends ParentNode {
    * @return text from all childNodes.
    */
   get textContent(): string {
-    return super.textContent;
+    return this.getTextContent();
   }
 
   /**

--- a/src/worker-thread/dom/Node.ts
+++ b/src/worker-thread/dom/Node.ts
@@ -106,6 +106,13 @@ export abstract class Node {
    * @return text from all childNodes.
    */
   get textContent(): string {
+    return this.getTextContent();
+  }
+
+  /**
+   * Use `this.getTextContent()` instead of `super.textContent` to avoid incorrect or expensive ES5 transpilation.
+   */
+  protected getTextContent(): string {
     let textContent = '';
     const childNodes = this.childNodes;
 


### PR DESCRIPTION
Fixes #326. Also fixes bunch of tests for #319 due to Preact browser tests' use of `babel-register`.

#328 fixes the same issue for worker-dom's ES5 output, but not for projects that import the ES6 output and have their own transpilation pipeline (e.g. amphtml). Plus, the spec-compliant Babel transpile is pretty large.