### PR TITLE
Node.replaceChild() must set parentNode of newChild

### DIFF
--- a/src/test/node/replaceChild.ts
+++ b/src/test/node/replaceChild.ts
@@ -19,47 +19,63 @@ import { Element } from '../../worker-thread/dom/Element';
 import { createDocument } from '../../worker-thread/dom/Document';
 
 const test = anyTest as TestInterface<{
-  node: Element;
-  child: Element;
-  childTwo: Element;
-  childThree: Element;
+  parent: Element;
+  x: Element;
+  y: Element;
+  z: Element;
 }>;
 
 test.beforeEach(t => {
   const document = createDocument();
 
   t.context = {
-    node: document.createElement('div'),
-    child: document.createElement('div'),
-    childTwo: document.createElement('p'),
-    childThree: document.createElement('section'),
+    parent: document.createElement('div'),
+    x: document.createElement('div'),
+    y: document.createElement('p'),
+    z: document.createElement('section'),
   };
 });
 
 test('replacing the same child results in no changes', t => {
-  const { node, child } = t.context;
+  const { parent, x } = t.context;
 
-  node.appendChild(child);
-  var previousNodes = node.childNodes;
-  t.deepEqual(node.replaceChild(child, child), child, 'replaceChild returns node replaced even when NOOP');
-  t.deepEqual(node.childNodes, previousNodes, 'child list remains the same after replacing one child with itself');
+  parent.appendChild(x);
+  t.is(x.parentNode, parent);
+
+  const replaced = parent.replaceChild(x, x);
+
+  t.is(x.parentNode, parent);
+  t.is(replaced, x);
+  t.deepEqual(parent.childNodes, [x]);
 });
 
 test('replacing a child with another when there is only a single child', t => {
-  const { node, child, childTwo } = t.context;
+  const { parent, x, y } = t.context;
 
-  node.appendChild(child);
-  t.deepEqual(node.replaceChild(childTwo, child), child, 'replacing a child returns the removed child');
-  t.deepEqual(node.childNodes[0], childTwo, 'the first child is now childTwo');
-  t.is(node.childNodes.length, 1, 'the number of nodes remains at one');
+  parent.appendChild(x);
+  t.is(x.parentNode, parent);
+  t.is(y.parentNode, null);
+
+  const replaced = parent.replaceChild(y, x);
+
+  t.is(replaced, x);
+  t.is(x.parentNode, null);
+  t.is(y.parentNode, parent);
+  t.deepEqual(parent.childNodes, [y]);
 });
 
 test('replacing a child with another when there are multiple children', t => {
-  const { node, child, childTwo, childThree } = t.context;
+  const { parent, x, y, z } = t.context;
 
-  node.appendChild(child);
-  node.appendChild(childTwo);
-  t.deepEqual(node.replaceChild(childThree, childTwo), childTwo, 'replacing a child returns the removed child');
-  t.deepEqual(node.childNodes[1], childThree, 'the last child is now childThree');
-  t.is(node.childNodes.length, 2, 'the number of nodes remains at two');
+  parent.appendChild(x);
+  parent.appendChild(y);
+  t.is(x.parentNode, parent);
+  t.is(y.parentNode, parent);
+
+  const replaced = parent.replaceChild(z, y);
+
+  t.is(replaced, y);
+  t.is(y.parentNode, null);
+  t.is(z.parentNode, parent);
+  t.deepEqual(parent.childNodes, [x, z]);
 });

--- a/src/worker-thread/dom/Node.ts
+++ b/src/worker-thread/dom/Node.ts
@@ -292,6 +292,7 @@ export abstract class Node {
         propagate(oldChild, 'isConnected', false);
         propagate(oldChild, TransferrableKeys.scopingRoot, oldChild);
         this.childNodes.splice(index, 1, newChild);
+        newChild.parentNode = this;
         propagate(newChild, 'isConnected', this.isConnected);
         propagate(newChild, TransferrableKeys.scopingRoot, this[TransferrableKeys.scopingRoot]);
 


### PR DESCRIPTION
Fixes a couple tests in #319. Would've been a nightmare for a publisher using Preact/React to find.