### PR TITLE
Add Navigator

### DIFF
--- a/src/worker-thread/WorkerDOMGlobalScope.ts
+++ b/src/worker-thread/WorkerDOMGlobalScope.ts
@@ -48,6 +48,7 @@ import { HydrateableNode } from '../transfer/TransferrableNodes';
 
 export interface WorkerDOMGlobalScope {
   document: Document;
+  navigator: WorkerNavigator;
   addEventListener: (type: string, handler: EventHandler) => void;
   removeEventListener: (type: string, handler: EventHandler) => void;
   localStorage: object;

--- a/src/worker-thread/index.safe.ts
+++ b/src/worker-thread/index.safe.ts
@@ -129,6 +129,7 @@ const WHITELISTED_GLOBALS = [
 const doc = createDocument((self as DedicatedWorkerGlobalScope).postMessage);
 export const workerDOM: WorkerDOMGlobalScope = {
   document: doc,
+  navigator: (self as WorkerGlobalScope).navigator,
   addEventListener: doc.addEventListener.bind(doc),
   removeEventListener: doc.removeEventListener.bind(doc),
   localStorage: {},

--- a/src/worker-thread/index.ts
+++ b/src/worker-thread/index.ts
@@ -52,6 +52,7 @@ declare var __ALLOW_POST_MESSAGE__: boolean;
 const doc = createDocument(__ALLOW_POST_MESSAGE__ ? (self as DedicatedWorkerGlobalScope).postMessage : undefined);
 export const workerDOM: WorkerDOMGlobalScope = {
   document: doc,
+  navigator: (self as WorkerGlobalScope).navigator,
   addEventListener: doc.addEventListener.bind(doc),
   removeEventListener: doc.removeEventListener.bind(doc),
   localStorage: {},


### PR DESCRIPTION
- Add `WorkerGlobalScope.navigator` to `WorkerDOMGlobalScope`.
- This will come as a `WorkerNavigator`, a subset of the `Navigator` interface.

@jridgewell @choumx 