### PR TITLE
Fix Node.replaceChild when newChild is already a child

### DIFF
--- a/src/test/mutationobserver/replaceChild.ts
+++ b/src/test/mutationobserver/replaceChild.ts
@@ -115,15 +115,21 @@ test.serial.cb('replaceChild mutation, remove sibling node', t => {
   const p = document.createElement('p');
   const observer = new document.defaultView.MutationObserver(
     (mutations: MutationRecord[]): void => {
-      t.deepEqual(mutations, [
-        {
-          type: MutationRecordType.CHILD_LIST,
-          target: document.body,
-          removedNodes: [p],
-          addedNodes: [div],
-          nextSibling: undefined,
-        },
-      ]);
+      t.is(mutations.length, 2);
+
+      // Mutation for removeChild(div).
+      const one = mutations[0];
+      t.is(one.type, MutationRecordType.CHILD_LIST);
+      t.is(one.target, document.body);
+      t.deepEqual(one.removedNodes, [div]);
+
+      // Mutation for replaceChild(div, p).
+      const two = mutations[1];
+      t.is(two.type, MutationRecordType.CHILD_LIST);
+      t.is(two.target, document.body);
+      t.deepEqual(two.removedNodes, [p]); // [div]
+      t.deepEqual(two.addedNodes, [div]); // []
+      t.is(two.nextSibling, undefined);
       observer.disconnect();
       t.end();
     },

--- a/src/test/node/replaceChild.ts
+++ b/src/test/node/replaceChild.ts
@@ -130,7 +130,7 @@ test('replacing a child with an ancestor', t => {
   t.deepEqual(parent.childNodes, [child]);
   t.deepEqual(child.childNodes, [grandchild]);
 
-  // Replacing with child should be a no-op.
+  // Replacing with ancestor should be a no-op.
   replaced = child.replaceChild(parent, grandchild);
   t.is(replaced, grandchild);
   t.is(child.parentNode, parent);

--- a/src/test/node/replaceChild.ts
+++ b/src/test/node/replaceChild.ts
@@ -80,7 +80,7 @@ test('replacing a child with another when there are multiple children', t => {
   t.deepEqual(parent.childNodes, [x, z]);
 });
 
-test('replacing a child with another child', t => {
+test('replacing a child with next sibling', t => {
   const { parent, x, y } = t.context;
 
   parent.appendChild(x);
@@ -94,6 +94,22 @@ test('replacing a child with another child', t => {
   t.is(x.parentNode, null);
   t.is(y.parentNode, parent);
   t.deepEqual(parent.childNodes, [y]);
+});
+
+test('replacing a child with previous sibling', t => {
+  const { parent, x, y } = t.context;
+
+  parent.appendChild(x);
+  parent.appendChild(y);
+  t.is(x.parentNode, parent);
+  t.is(y.parentNode, parent);
+
+  const replaced = parent.replaceChild(x, y);
+
+  t.is(replaced, y);
+  t.is(x.parentNode, parent);
+  t.is(y.parentNode, null);
+  t.deepEqual(parent.childNodes, [x]);
 });
 
 test('replacing a child with an ancestor', t => {

--- a/src/test/node/replaceChild.ts
+++ b/src/test/node/replaceChild.ts
@@ -79,3 +79,46 @@ test('replacing a child with another when there are multiple children', t => {
   t.is(z.parentNode, parent);
   t.deepEqual(parent.childNodes, [x, z]);
 });
+
+test('replacing a child with another child', t => {
+  const { parent, x, y } = t.context;
+
+  parent.appendChild(x);
+  parent.appendChild(y);
+  t.is(x.parentNode, parent);
+  t.is(y.parentNode, parent);
+
+  const replaced = parent.replaceChild(y, x);
+
+  t.is(replaced, x);
+  t.is(x.parentNode, null);
+  t.is(y.parentNode, parent);
+  t.deepEqual(parent.childNodes, [y]);
+});
+
+test('replacing a child with an ancestor', t => {
+  const { parent, x: child, y: grandchild } = t.context;
+
+  parent.appendChild(child);
+  child.appendChild(grandchild);
+  t.is(child.parentNode, parent);
+  t.is(grandchild.parentNode, child);
+  t.deepEqual(parent.childNodes, [child]);
+  t.deepEqual(child.childNodes, [grandchild]);
+
+  // Replacing with self should be a no-op.
+  let replaced = child.replaceChild(child, grandchild);
+  t.is(replaced, grandchild);
+  t.is(child.parentNode, parent);
+  t.is(grandchild.parentNode, child);
+  t.deepEqual(parent.childNodes, [child]);
+  t.deepEqual(child.childNodes, [grandchild]);
+
+  // Replacing with child should be a no-op.
+  replaced = child.replaceChild(parent, grandchild);
+  t.is(replaced, grandchild);
+  t.is(child.parentNode, parent);
+  t.is(grandchild.parentNode, child);
+  t.deepEqual(parent.childNodes, [child]);
+  t.deepEqual(child.childNodes, [grandchild]);
+});

--- a/src/worker-thread/dom/Node.ts
+++ b/src/worker-thread/dom/Node.ts
@@ -295,6 +295,8 @@ export abstract class Node {
       return oldChild;
     }
     // If newChild already exists in the DOM, it is first removed.
+    // TODO: Consider using a mutation-free API here to avoid two mutations
+    // per replaceChild() call.
     newChild.remove();
 
     oldChild.parentNode = null;

--- a/src/worker-thread/dom/Node.ts
+++ b/src/worker-thread/dom/Node.ts
@@ -285,15 +285,13 @@ export abstract class Node {
    * @see https://dom.spec.whatwg.org/#concept-node-replace
    */
   public replaceChild(newChild: Node, oldChild: Node): Node {
-    if (newChild === oldChild) {
-      return oldChild;
-    }
-    if (oldChild.parentNode !== this) {
+    if (
+      newChild === oldChild ||
       // In DOM, this throws DOMException: "The node to be replaced is not a child of this node."
-      return oldChild;
-    }
-    if (newChild.contains(this)) {
+      oldChild.parentNode !== this ||
       // In DOM, this throws DOMException: "The new child element contains the parent."
+      newChild.contains(this)
+    ) {
       return oldChild;
     }
     // If newChild already exists in the DOM, it is first removed.

--- a/src/worker-thread/dom/Node.ts
+++ b/src/worker-thread/dom/Node.ts
@@ -277,35 +277,46 @@ export abstract class Node {
     return null;
   }
 
-  // TODO(KB): Verify behaviour.
   /**
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/Node/replaceChild
-   * @param newChild new Node to replace old Node.
-   * @param oldChild existing Node to be replaced.
+   * @param newChild
+   * @param oldChild
    * @return child that was replaced.
+   * @note `HierarchyRequestError` not handled e.g. newChild is an ancestor of current node.
+   * @see https://dom.spec.whatwg.org/#concept-node-replace
    */
   public replaceChild(newChild: Node, oldChild: Node): Node {
-    if (newChild !== oldChild) {
-      const index = this.childNodes.indexOf(oldChild);
-      if (index >= 0) {
-        oldChild.parentNode = null;
-        propagate(oldChild, 'isConnected', false);
-        propagate(oldChild, TransferrableKeys.scopingRoot, oldChild);
-        this.childNodes.splice(index, 1, newChild);
-        newChild.parentNode = this;
-        propagate(newChild, 'isConnected', this.isConnected);
-        propagate(newChild, TransferrableKeys.scopingRoot, this[TransferrableKeys.scopingRoot]);
-
-        mutate({
-          addedNodes: [newChild],
-          removedNodes: [oldChild],
-          type: MutationRecordType.CHILD_LIST,
-          nextSibling: this.childNodes[index + 1],
-          target: this,
-        });
-      }
+    if (newChild === oldChild) {
+      return oldChild;
     }
+    if (oldChild.parentNode !== this) {
+      // In DOM, this throws DOMException: "The node to be replaced is not a child of this node."
+      return oldChild;
+    }
+    if (newChild.contains(this)) {
+      // In DOM, this throws DOMException: "The new child element contains the parent."
+      return oldChild;
+    }
+    // If newChild already exists in the DOM, it is first removed.
+    newChild.remove();
 
+    oldChild.parentNode = null;
+    propagate(oldChild, 'isConnected', false);
+    propagate(oldChild, TransferrableKeys.scopingRoot, oldChild);
+
+    const index = this.childNodes.indexOf(oldChild);
+    this.childNodes.splice(index, 1, newChild);
+
+    newChild.parentNode = this;
+    propagate(newChild, 'isConnected', this.isConnected);
+    propagate(newChild, TransferrableKeys.scopingRoot, this[TransferrableKeys.scopingRoot]);
+
+    mutate({
+      addedNodes: [newChild],
+      removedNodes: [oldChild],
+      type: MutationRecordType.CHILD_LIST,
+      nextSibling: this.childNodes[index + 1],
+      target: this,
+    });
     return oldChild;
   }
 


### PR DESCRIPTION
Partial for #319.

Importantly, fixes this bug:
```js
parent.appendChild(one);
parent.appendChild(two);
parent.replaceChild(two, one);

// Expected: [one]
// Actual: [one, one]
log(parent.childNodes); 
```

Also fixes one case of [HierarchyRequestError](https://dom.spec.whatwg.org/#concept-node-replace) where newChild is an ancestor of parent.