### PR TITLE
Node.outerHTML: Don't output end tags for void elements 

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,12 +86,12 @@
     {
       "path": "./dist/worker.mjs",
       "compression": "brotli",
-      "maxSize": "8 kB"
+      "maxSize": "8.2 kB"
     },
     {
       "path": "./dist/worker.safe.mjs",
       "compression": "brotli",
-      "maxSize": "8.4 kB"
+      "maxSize": "8.5 kB"
     },
     {
       "path": "./dist/index.mjs",

--- a/src/test/element/outerHTML.ts
+++ b/src/test/element/outerHTML.ts
@@ -16,9 +16,10 @@
 
 import anyTest, { TestInterface } from 'ava';
 import { Element } from '../../worker-thread/dom/Element';
-import { createDocument } from '../../worker-thread/dom/Document';
+import { createDocument, Document } from '../../worker-thread/dom/Document';
 
 const test = anyTest as TestInterface<{
+  document: Document;
   node: Element;
   child: Element;
 }>;
@@ -27,6 +28,7 @@ test.beforeEach(t => {
   const document = createDocument();
 
   t.context = {
+    document,
     node: document.createElement('div'),
     child: document.createElement('div'),
   };
@@ -45,4 +47,33 @@ test('element with a child', t => {
 
   node.appendChild(child);
   t.is(node.outerHTML, '<div><div></div></div>');
+});
+
+test('void elements without children', t => {
+  const { document } = t.context;
+
+  t.is(document.createElement('area').outerHTML, '<area>');
+  t.is(document.createElement('base').outerHTML, '<base>');
+  t.is(document.createElement('br').outerHTML, '<br>');
+  t.is(document.createElement('col').outerHTML, '<col>');
+  t.is(document.createElement('embed').outerHTML, '<embed>');
+  t.is(document.createElement('hr').outerHTML, '<hr>');
+  t.is(document.createElement('img').outerHTML, '<img>');
+  t.is(document.createElement('input').outerHTML, '<input>');
+  t.is(document.createElement('link').outerHTML, '<link>');
+  t.is(document.createElement('meta').outerHTML, '<meta>');
+  t.is(document.createElement('param').outerHTML, '<param>');
+  t.is(document.createElement('source').outerHTML, '<source>');
+  t.is(document.createElement('track').outerHTML, '<track>');
+  t.is(document.createElement('wbr').outerHTML, '<wbr>');
+});
+
+test('void elements with children', t => {
+  const { document, child } = t.context;
+
+  const input = document.createElement('input');
+  t.is(input.outerHTML, '<input>');
+
+  input.appendChild(child);
+  t.is(input.outerHTML, '<input><div></div></input>');
 });


### PR DESCRIPTION
Partial for #319. Fixes bugs like this:

```ts
const input = document.createElement('input');
// Expected: '<input>'
// Actual: '<input></input>'
console.log(input.outerHTML);
```