### PR TITLE
Support non-string edge case for set cssText

### DIFF
--- a/src/test/cssstyledeclaration/setCssText.ts
+++ b/src/test/cssstyledeclaration/setCssText.ts
@@ -104,3 +104,15 @@ test('setting cssText with a single miscapitalized value requiring key conversio
   declaration.cssText = '-webkit-linE-height: 10px';
   t.is(declaration.webkitLineHeight, '10px');
 });
+
+test('setting cssText with a non-string should set empty string instead', t => {
+  const declaration = new CSSStyleDeclaration(t.context.node);
+  appendKeys(['width']);
+  t.is(declaration.cssText, '');
+
+  declaration.cssText = 'width: 10px;';
+  t.is(declaration.width, '10px');
+
+  declaration.cssText = { width: '10px' } as any;
+  t.is(declaration.cssText, '');
+});

--- a/src/worker-thread/css/CSSStyleDeclaration.ts
+++ b/src/worker-thread/css/CSSStyleDeclaration.ts
@@ -155,9 +155,13 @@ export class CSSStyleDeclaration implements StyleDeclaration {
    * @param value css text string to parse and store
    */
   set cssText(value: string) {
+    // value should have an "unknown" type but get/set can't have different types.
+    // https://github.com/Microsoft/TypeScript/issues/2521
+    const stringValue = typeof value === 'string' ? value : '';
+
     this[TransferrableKeys.properties] = {};
 
-    const values = value.split(/[:;]/);
+    const values = stringValue.split(/[:;]/);
     const length = values.length;
     for (let index = 0; index + 1 < length; index += 2) {
       this[TransferrableKeys.properties][toLower(values[index].trim())] = values[index + 1].trim();


### PR DESCRIPTION
Partial for #319.

Older versions (> ~2 weeks ago) of Preact supports objects when rendering `style` in JSX, which results in setting `cssText` to a non-string:

https://github.com/developit/preact/blob/3aaa578270c0c6cd1fb7f5cf992737eec2934433/src/dom/index.js#L81-L83

Looks like they've made a bunch of changes since. Time to pull and try everything again. 😫 