### PR TITLE
Wrapper for longTask functions

### DIFF
--- a/demo/long-task/index.html
+++ b/demo/long-task/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Hello World</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="/demo.css" rel="stylesheet">
+  <script src="/dist/index.mjs" type="module"></script>
+  <script src="/dist/index.js" nomodule defer></script>
+  <!-- This comment block is intended to make it easier to test both the script module and nomodule path -->
+  <!-- Comment either block to enable module/nomodule or disable it. -->
+  <!-- <script src="/dist/index.js" defer></script> -->
+  <style>
+    #status-element {
+      margin-top: 16px;
+      border: 1px dashed lightgray;
+      font-size: smaller;
+      opacity: 0.7;
+    }
+  </style>
+</head>
+<body>
+  <div src="long-task-demo.js" id="upgrade-me">
+    <div class="root">
+      <button>Run long task</button>
+    </div>
+  </div>
+  <div id="status-element">
+  </div>
+  <script type="module">
+    import {upgradeElement} from '/dist/index.mjs';
+    upgradeElement(document.getElementById('upgrade-me'), '/dist/worker.mjs', {
+      onLongTask: (promise, opt_message) => {
+        const statusElement = document.getElementById('status-element');
+        statusElement.textContent = opt_message || 'Long task is running...';
+        promise.then(() => {
+          statusElement.textContent = '';
+        });
+      },
+    });
+  </script>
+  <script nomodule async=false defer>
+    document.addEventListener('DOMContentLoaded', function() {
+      MainThread.upgradeElement(document.getElementById('upgrade-me'), '/dist/worker.js');
+    }, false);
+  </script>
+  <!-- This comment block is intended to make it easier to test both the script module and nomodule path -->
+  <!-- Comment either block to enable module/nomodule or disable it. -->
+  <!-- <script async=false defer>
+    document.addEventListener('DOMContentLoaded', function() {
+      MainThread.upgradeElement(document.getElementById('upgrade-me'), './dist/worker.js');
+    }, false);
+  </script> -->
+</body>
+</html>

--- a/demo/long-task/long-task-demo.js
+++ b/demo/long-task/long-task-demo.js
@@ -16,13 +16,12 @@
 
 const btn = document.getElementsByTagName('button')[0];
 
-btn.addEventListener('click', async () => {
-  longTask(
-      new Promise(resolve => setTimeout(resolve, 5000))
-          .then(() => {
-            const h1 = document.createElement('h1');
-            h1.textContent = 'Hello World!'
-            document.body.appendChild(h1);
-          }),
-      'long task running...');
-});
+btn.addEventListener('click', longTask.wrap(e => {
+  console.log('event: ', e);
+  return new Promise(resolve => setTimeout(resolve, 5000))
+      .then(() => {
+        const h1 = document.createElement('h1');
+        h1.textContent = 'Hello World!'
+        document.body.appendChild(h1);
+      });
+}, 'long task running...'));

--- a/demo/long-task/long-task-demo.js
+++ b/demo/long-task/long-task-demo.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-import { WorkerCallbacks } from './callbacks';
-import { WorkerDom } from './worker-dom';
-import { fetchAndInstall } from './install';
+const btn = document.getElementsByTagName('button')[0];
 
-export function upgradeElement(baseElement: Element, workerDOMUrl: string, callbacks?: WorkerCallbacks): Promise<WorkerDom | null> {
-  const authorURL = baseElement.getAttribute('src');
-  if (authorURL) {
-    return fetchAndInstall(baseElement as HTMLElement, authorURL, workerDOMUrl, callbacks);
-  }
-  return Promise.resolve(null);
-}
+btn.addEventListener('click', async () => {
+  longTask(
+      new Promise(resolve => setTimeout(resolve, 5000))
+          .then(() => {
+            const h1 = document.createElement('h1');
+            h1.textContent = 'Hello World!'
+            document.body.appendChild(h1);
+          }),
+      'long task running...');
+});

--- a/package.json
+++ b/package.json
@@ -98,12 +98,12 @@
     {
       "path": "./dist/index.mjs",
       "compression": "brotli",
-      "maxSize": "3.0 kB"
+      "maxSize": "3.05 kB"
     },
     {
       "path": "./dist/index.safe.mjs",
       "compression": "brotli",
-      "maxSize": "8.2 kB"
+      "maxSize": "8.25 kB"
     }
   ],
   "esm": {

--- a/package.json
+++ b/package.json
@@ -93,17 +93,17 @@
     {
       "path": "./dist/worker.safe.mjs",
       "compression": "brotli",
-      "maxSize": "8.5 kB"
+      "maxSize": "8.55 kB"
     },
     {
       "path": "./dist/index.mjs",
       "compression": "brotli",
-      "maxSize": "2.84 kB"
+      "maxSize": "3.0 kB"
     },
     {
       "path": "./dist/index.safe.mjs",
       "compression": "brotli",
-      "maxSize": "8.1 kB"
+      "maxSize": "8.2 kB"
     }
   ],
   "esm": {

--- a/src/main-thread/callbacks.ts
+++ b/src/main-thread/callbacks.ts
@@ -24,6 +24,10 @@ import { Phase } from '../transfer/phase';
  */
 export type MutationPumpFunction = (flush: Function, phase: Phase) => void;
 
+/**
+ */
+export type LongTaskFunction = (promise: Promise<any>) => void;
+
 export interface WorkerCallbacks {
   // Called when worker consumes the page's initial DOM state.
   onCreateWorker?: (initialDOM: RenderableElement) => void;
@@ -35,4 +39,6 @@ export interface WorkerCallbacks {
   onReceiveMessage?: (message: MessageFromWorker) => void;
   // Called to schedule mutation phase. See `MutationPumpFunction`.
   onMutationPump?: MutationPumpFunction;
+  // Called to schedule long task. See `LongTaskFunction`.
+  onLongTask?: LongTaskFunction;
 }

--- a/src/main-thread/commands/long-task.ts
+++ b/src/main-thread/commands/long-task.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LongTaskFunction, WorkerCallbacks } from '../callbacks';
+import { TransferrableMutationRecord } from '../../transfer/TransferrableRecord';
+
+export class LongTaskProcessor {
+  private onLongTask: LongTaskFunction | null;
+  private currentResolver: Function | null;
+
+  constructor(callbacks?: WorkerCallbacks) {
+    this.onLongTask = (callbacks && callbacks.onLongTask) || null;
+    this.currentResolver = null;
+  }
+
+  /**
+   * Process commands transfered from worker thread to main thread.
+   * @param mutation mutation record containing commands to execute.
+   */
+  processStart(mutation: TransferrableMutationRecord): void {
+    if (!this.onLongTask) {
+      return;
+    }
+    if (this.currentResolver) {
+      this.currentResolver();
+      this.currentResolver = null;
+    }
+    const promise = new Promise(resolve => {
+      this.currentResolver = resolve;
+    });
+    this.onLongTask(promise);
+  }
+
+  /**
+   * Process commands transfered from worker thread to main thread.
+   * @param mutation mutation record containing commands to execute.
+   */
+  processEnd(mutation: TransferrableMutationRecord): void {
+    if (this.currentResolver) {
+      this.currentResolver();
+      this.currentResolver = null;
+    }
+  }
+}

--- a/src/main-thread/debugging.ts
+++ b/src/main-thread/debugging.ts
@@ -22,7 +22,16 @@
  * @see https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#9.4
  */
 
-import { EventToWorker, MessageFromWorker, MessageType, MessageToWorker, ValueSyncToWorker, BoundingClientRectToWorker } from '../transfer/Messages';
+import {
+  EventToWorker,
+  MessageFromWorker,
+  MessageType,
+  MessageToWorker,
+  ValueSyncToWorker,
+  BoundingClientRectToWorker,
+  LongTaskStartToWorker,
+  LongTaskEndToWorker,
+} from '../transfer/Messages';
 import { HydrateableNode, TransferredNode } from '../transfer/TransferrableNodes';
 import { NodeContext } from './nodes';
 import { TransferrableEvent } from '../transfer/TransferrableEvent';
@@ -42,6 +51,8 @@ const MUTATION_RECORD_TYPE_REVERSE_MAPPING = {
   '3': 'PROPERTIES',
   '4': 'EVENT_SUBSCRIPTION',
   '5': 'GET_BOUNDING_CLIENT_RECT',
+  '6': 'LONG_TASK_START',
+  '7': 'LONG_TASK_END',
 };
 
 export class DebuggingContext {
@@ -104,6 +115,10 @@ export class DebuggingContext {
         type: 'GET_BOUNDING_CLIENT_RECT',
         target: readableTransferredNode(this.nodeContext, message[TransferrableKeys.target]),
       };
+    } else if (isLongTaskStart(message)) {
+      return { type: 'LONG_TASK_START' };
+    } else if (isLongTaskEnd(message)) {
+      return { type: 'LONG_TASK_END' };
     } else {
       return 'Unrecognized MessageToWorker type: ' + message[TransferrableKeys.type];
     }
@@ -218,6 +233,20 @@ function isValueSync(message: MessageToWorker): message is ValueSyncToWorker {
  */
 function isBoundingClientRect(message: MessageToWorker): message is BoundingClientRectToWorker {
   return message[TransferrableKeys.type] === MessageType.GET_BOUNDING_CLIENT_RECT;
+}
+
+/**
+ * @param data
+ */
+function isLongTaskStart(message: MessageToWorker): message is LongTaskStartToWorker {
+  return message[TransferrableKeys.type] === MessageType.LONG_TASK_START;
+}
+
+/**
+ * @param data
+ */
+function isLongTaskEnd(message: MessageToWorker): message is LongTaskEndToWorker {
+  return message[TransferrableKeys.type] === MessageType.LONG_TASK_END;
 }
 
 /**

--- a/src/main-thread/install.ts
+++ b/src/main-thread/install.ts
@@ -76,7 +76,7 @@ export function install(
     if (workerDOMScript && authorScript && authorScriptURL) {
       const workerContext = new WorkerContext(baseElement, workerDOMScript, authorScript, authorScriptURL, callbacks);
       const worker = workerContext.getWorker();
-      const mutatorContext = new MutatorProcessor(strings, nodeContext, workerContext, callbacks && callbacks.onMutationPump, sanitizer);
+      const mutatorContext = new MutatorProcessor(strings, nodeContext, workerContext, callbacks, sanitizer);
       worker.onmessage = (message: MessageFromWorker) => {
         const { data } = message;
         const type = data[TransferrableKeys.type];
@@ -135,5 +135,6 @@ function wrapCallbacks(debuggingContext: DebuggingContext, callbacks?: WorkerCal
     },
     // Passthrough callbacks:
     onMutationPump: callbacks && callbacks.onMutationPump,
+    onLongTask: callbacks && callbacks.onLongTask,
   };
 }

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -59,6 +59,7 @@ export class WorkerContext {
         var Document = defaultView.Document;
         var Event = defaultView.Event;
         var MutationObserver = defaultView.MutationObserver;
+        var longTask = this.longTask;
 
         function addEventListener(type, handler) {
           return document.addEventListener(type, handler);

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -60,6 +60,13 @@ export class WorkerContext {
         var Event = defaultView.Event;
         var MutationObserver = defaultView.MutationObserver;
         var longTask = this.longTask;
+        longTask.wrap = function(callback, opt_message) {
+          return function() {
+            longTask(
+                Promise.resolve(callback.apply(null, arguments)),
+                opt_message);
+          };
+        };
 
         function addEventListener(type, handler) {
           return document.addEventListener(type, handler);

--- a/src/test/main-thread/mutator.ts
+++ b/src/test/main-thread/mutator.ts
@@ -129,7 +129,7 @@ test.serial('batch mutations with custom pump', t => {
     tasks.push({ phase, flush });
   };
 
-  const mutator = new MutatorProcessor(strings, nodeContext, workerContext, mutationPump);
+  const mutator = new MutatorProcessor(strings, nodeContext, workerContext, { onMutationPump: mutationPump });
 
   mutator.mutate(
     Phase.Mutating,

--- a/src/transfer/Messages.ts
+++ b/src/transfer/Messages.ts
@@ -28,9 +28,11 @@ export const enum MessageType {
   MUTATE = 3,
   SYNC = 4,
   GET_BOUNDING_CLIENT_RECT = 5,
-  // NAVIGATION_PUSH_STATE = 6,
-  // NAVIGATION_REPLACE_STATE = 7,
-  // NAVIGATION_POP_STATE = 8,
+  LONG_TASK_START = 6,
+  LONG_TASK_END = 7,
+  // NAVIGATION_PUSH_STATE = 8,
+  // NAVIGATION_REPLACE_STATE = 9,
+  // NAVIGATION_POP_STATE = 10,
 }
 
 export interface MutationFromWorker {
@@ -61,4 +63,10 @@ export interface BoundingClientRectToWorker {
   [TransferrableKeys.target]: TransferredNode;
   [TransferrableKeys.data]: TransferrableBoundingClientRect;
 }
-export type MessageToWorker = EventToWorker | ValueSyncToWorker | BoundingClientRectToWorker;
+export interface LongTaskStartToWorker {
+  [TransferrableKeys.type]: MessageType.LONG_TASK_START;
+}
+export interface LongTaskEndToWorker {
+  [TransferrableKeys.type]: MessageType.LONG_TASK_END;
+}
+export type MessageToWorker = EventToWorker | ValueSyncToWorker | BoundingClientRectToWorker | LongTaskStartToWorker | LongTaskEndToWorker;

--- a/src/worker-thread/MutationRecord.ts
+++ b/src/worker-thread/MutationRecord.ts
@@ -63,4 +63,6 @@ export const enum MutationRecordType {
   PROPERTIES = 3,
   EVENT_SUBSCRIPTION = 4,
   GET_BOUNDING_CLIENT_RECT = 5,
+  LONG_TASK_START = 6,
+  LONG_TASK_END = 7,
 }

--- a/src/worker-thread/WorkerDOMGlobalScope.ts
+++ b/src/worker-thread/WorkerDOMGlobalScope.ts
@@ -56,6 +56,7 @@ export interface WorkerDOMGlobalScope {
   url: string;
   appendKeys: (keys: Array<string>) => void;
   consumeInitialDOM: (document: Document, strings: Array<string>, hydrateableNode: HydrateableNode) => void;
+  longTask: (promise: Promise<any>, message?: string) => Promise<any>;
   HTMLAnchorElement: typeof HTMLAnchorElement;
   HTMLButtonElement: typeof HTMLButtonElement;
   HTMLDataElement: typeof HTMLDataElement;

--- a/src/worker-thread/index.safe.ts
+++ b/src/worker-thread/index.safe.ts
@@ -46,6 +46,7 @@ import { createDocument } from './dom/Document';
 import { WorkerDOMGlobalScope } from './WorkerDOMGlobalScope';
 import { appendKeys } from './css/CSSStyleDeclaration';
 import { consumeInitialDOM } from './initialize';
+import { LongTask } from './long-task';
 
 const WHITELISTED_GLOBALS = [
   'Array',
@@ -127,6 +128,7 @@ const WHITELISTED_GLOBALS = [
 ];
 
 const doc = createDocument((self as DedicatedWorkerGlobalScope).postMessage);
+const longTask = new LongTask(doc);
 export const workerDOM: WorkerDOMGlobalScope = {
   document: doc,
   navigator: (self as WorkerGlobalScope).navigator,
@@ -137,6 +139,7 @@ export const workerDOM: WorkerDOMGlobalScope = {
   url: '/',
   appendKeys,
   consumeInitialDOM,
+  longTask: longTask.execute.bind(longTask),
   HTMLAnchorElement,
   HTMLButtonElement,
   HTMLDataElement,

--- a/src/worker-thread/index.ts
+++ b/src/worker-thread/index.ts
@@ -46,10 +46,12 @@ import { createDocument } from './dom/Document';
 import { WorkerDOMGlobalScope } from './WorkerDOMGlobalScope';
 import { appendKeys } from './css/CSSStyleDeclaration';
 import { consumeInitialDOM } from './initialize';
+import { LongTask } from './long-task';
 
 declare var __ALLOW_POST_MESSAGE__: boolean;
 
 const doc = createDocument(__ALLOW_POST_MESSAGE__ ? (self as DedicatedWorkerGlobalScope).postMessage : undefined);
+const longTask = new LongTask(doc);
 export const workerDOM: WorkerDOMGlobalScope = {
   document: doc,
   navigator: (self as WorkerGlobalScope).navigator,
@@ -60,6 +62,7 @@ export const workerDOM: WorkerDOMGlobalScope = {
   url: '/',
   appendKeys,
   consumeInitialDOM,
+  longTask: longTask.execute.bind(longTask),
   HTMLAnchorElement,
   HTMLButtonElement,
   HTMLDataElement,

--- a/src/worker-thread/long-task.ts
+++ b/src/worker-thread/long-task.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Document } from './dom/Document';
+import { MutationRecordType } from './MutationRecord';
+import { mutate } from './MutationObserver';
+
+export class LongTask {
+  private doc: Document;
+
+  constructor(doc: Document) {
+    this.doc = doc;
+  }
+
+  execute(promise: Promise<any>, message?: string): Promise<any> {
+    // Start the task.
+    mutate({ type: MutationRecordType.LONG_TASK_START, target: this.doc });
+    return promise.then(
+      result => {
+        // Complete the task.
+        mutate({ type: MutationRecordType.LONG_TASK_END, target: this.doc });
+        return result;
+      },
+      reason => {
+        // Complete the task.
+        mutate({ type: MutationRecordType.LONG_TASK_END, target: this.doc });
+        throw reason;
+      },
+    );
+  }
+}


### PR DESCRIPTION
This would simply even callbacks.

From:
```
element.addEventListener('click', event => {
  longTask(fetch().then(() => mutate()));
});
```

To:
```
element.addEventListener('click', longTask.wrap(
    event => fetch().then(() => mutate())));
```
