### PR TITLE
Have innerHTML use document.createElement().

### DIFF
--- a/src/test/element/innerHTML.ts
+++ b/src/test/element/innerHTML.ts
@@ -20,6 +20,7 @@ import { Text } from '../../worker-thread/dom/Text';
 import { Comment } from '../../worker-thread/dom/Comment';
 import { NodeType, SVG_NAMESPACE } from '../../transfer/TransferrableNodes';
 import { createDocument } from '../../worker-thread/dom/Document';
+import { HTMLInputElement } from '../../worker-thread/dom/HTMLInputElement';
 
 const test = anyTest as TestInterface<{
   node: Element;
@@ -178,6 +179,13 @@ test('set normalizes html namespace tag names', t => {
   const child = node.firstChild!;
   t.is(child.localName, 'div');
   t.is(child.nodeName, 'DIV');
+});
+
+test('set creates correct types of HTML elements', t => {
+  const { node } = t.context;
+  node.innerHTML = '<input>';
+  const child = node.firstChild!;
+  t.true(child instanceof HTMLInputElement);
 });
 
 test.skip('set has svg tags live in SVG namespace', t => {

--- a/src/third_party/html-parser/html-parser.ts
+++ b/src/third_party/html-parser/html-parser.ts
@@ -180,19 +180,15 @@ export function parse(data: string, rootElement: Element) {
   if (!valid) {
     throw new Error('Attempting to parse invalid HTML content.');
   }
+  
+  const child = root.firstChild;
 
-  root.childNodes.forEach((node: Node) => {
-    if (node instanceof Element) {
-      node.parentNode = null;
-    }
-  });
-
-  // remove the added <div>
-  if (root.firstChild) {
-    root.firstChild.childNodes.forEach((node: Node) => {
-      node.parentNode = null;
+  if (child) {
+    child.parentNode = null;
+    child.childNodes.forEach((node: Node) => {
+      node.parentNode = null;    
     });
-    return root.firstChild;
+    return child;
   }
 
   throw new Error('Attempting to parse invalid HTML.');

--- a/src/third_party/html-parser/html-parser.ts
+++ b/src/third_party/html-parser/html-parser.ts
@@ -180,15 +180,15 @@ export function parse(data: string, rootElement: Element) {
   if (!valid) {
     throw new Error('Attempting to parse invalid HTML content.');
   }
-  
-  const child = root.firstChild;
 
-  if (child) {
-    child.parentNode = null;
-    child.childNodes.forEach((node: Node) => {
+  const wrapper = root.firstChild;
+
+  if (wrapper) {
+    wrapper.parentNode = null;
+    wrapper.childNodes.forEach((node: Node) => {
       node.parentNode = null;    
     });
-    return child;
+    return wrapper;
   }
 
   throw new Error('Attempting to parse invalid HTML.');

--- a/src/third_party/html-parser/html-parser.ts
+++ b/src/third_party/html-parser/html-parser.ts
@@ -189,10 +189,8 @@ export function parse(data: string, rootElement: Element) {
 
   // remove the added <div>
   if (root.firstChild) {
-    root.firstChild.childNodes.forEach((node: any) => {
-      if (node instanceof Node) {
-        node.parentNode = null;
-      }
+    root.firstChild.childNodes.forEach((node: Node) => {
+      node.parentNode = null;
     });
     return root.firstChild;
   }

--- a/src/worker-thread/dom/Element.ts
+++ b/src/worker-thread/dom/Element.ts
@@ -233,7 +233,7 @@ export class Element extends ParentNode {
     this.childNodes = [];
 
     // add new children
-    root.childNodes.forEach(n => {
+    root.childNodes.forEach((n: Node) => {
       this.appendChild(n);
     });
   }


### PR DESCRIPTION
- Instead of using `new Element()` inside of `html-parser`, use `document.createElement()`
- Instead of using `new Text()` inside of `html-parser`, use `document.createTextNode()`
- Instead of using `new Comment()` inside of `html-parser`, use `document.createComment()`
- Fixes #350 

@jridgewell @choumx 
cc/ @caroqliu 