### PR TITLE
Change the html-parser's wrapping element.

### DIFF
--- a/src/test/element/innerHTML.ts
+++ b/src/test/element/innerHTML.ts
@@ -172,9 +172,8 @@ test('set will alter root element\'s contents, not the element itself', t => {
   const document = createDocument();
   const pNode = document.createElement('p');
 
-  const testString = 'Hello World!';
-  pNode.innerHTML = testString;
-  t.is(pNode.textContent, testString);
+  pNode.innerHTML = 'Hello World!';
+  t.is(pNode.textContent, 'Hello World!');
 });
 
 test('set takes all block text element content as text', t => {

--- a/src/test/element/innerHTML.ts
+++ b/src/test/element/innerHTML.ts
@@ -159,10 +159,13 @@ test('set closes tags by closing others', t => {
   t.is(child.nodeName, 'DIV');
   t.is(child.firstChild!.nodeName, 'A');
 
-  node.innerHTML = '<a><div></div>';
-  child = node.firstChild!;
-  t.is(child.nodeName, 'A');
-  t.is(child.firstChild!.nodeName, 'DIV');
+  node.innerHTML = '<p><div></div>';
+  const pChild = node.firstChild!;
+  const divChild = node.lastChild!;
+  t.true(node.childNodes.length === 2);
+  t.is(pChild.nodeName, 'P');
+  t.is(divChild.nodeName, 'DIV');
+  
 });
 
 test('set takes all block text element content as text', t => {

--- a/src/test/element/innerHTML.ts
+++ b/src/test/element/innerHTML.ts
@@ -160,11 +160,8 @@ test('set closes tags by closing others', t => {
   t.is(child.firstChild!.nodeName, 'A');
 
   node.innerHTML = '<p><div></div>';
-  const pChild = node.firstChild!;
-  const divChild = node.lastChild!;
   t.true(node.childNodes.length === 2);
-  t.is(pChild.nodeName, 'P');
-  t.is(divChild.nodeName, 'DIV');
+  t.is(node.innerHTML, '<p></p><div></div>');
   
 });
 

--- a/src/test/element/innerHTML.ts
+++ b/src/test/element/innerHTML.ts
@@ -168,13 +168,13 @@ test('set closes tags by closing others', t => {
 // Some tags will automatically close others. Set innerHTML should consider this behavior, yet
 // it should not apply for the root element's tags:
 // https://github.com/ampproject/worker-dom/issues/372
-test('set will not alter root element', t => {
+test('set will alter root element\'s contents, not the element itself', t => {
   const document = createDocument();
   const pNode = document.createElement('p');
-  // normally, a <div> would automatically close a <p>
-  pNode.innerHTML = '<div></div>';
-  const child = pNode.firstChild!;
-  t.is(child.nodeName, 'DIV');
+
+  const testString = 'Hello World!';
+  pNode.innerHTML = testString;
+  t.is(pNode.textContent, testString);
 });
 
 test('set takes all block text element content as text', t => {

--- a/src/test/element/innerHTML.ts
+++ b/src/test/element/innerHTML.ts
@@ -165,7 +165,8 @@ test('set closes tags by closing others', t => {
   
 });
 
-// Expected behavior, as discussed in:
+// Some tags will automatically close others. Set innerHTML should consider this behavior, yet
+// it should not apply for the root element's tags:
 // https://github.com/ampproject/worker-dom/issues/372
 test('set will not alter root element', t => {
   const document = createDocument();

--- a/src/test/element/innerHTML.ts
+++ b/src/test/element/innerHTML.ts
@@ -168,6 +168,17 @@ test('set closes tags by closing others', t => {
   
 });
 
+// Expected behavior, as discussed in:
+// https://github.com/ampproject/worker-dom/issues/372
+test('set will not alter root element', t => {
+  const document = createDocument();
+  const pNode = document.createElement('p');
+  // normally, a <div> would automatically close a <p>
+  pNode.innerHTML = '<div></div>';
+  const child = pNode.firstChild!;
+  t.is(child.nodeName, 'DIV');
+});
+
 test('set takes all block text element content as text', t => {
   const { node } = t.context;
   node.innerHTML = '<style><div></div></style>';

--- a/src/third_party/html-parser/html-parser.ts
+++ b/src/third_party/html-parser/html-parser.ts
@@ -85,7 +85,7 @@ export function parse(data: string, rootElement: Element) {
   const stack = [root as Node];
   let lastTextPos = 0;
   let match: RegExpExecArray | null;
-  data = '<div>' + data + '</div>';
+  data = '<q>' + data + '</q>';
   const tagsClosed = [] as string[];
 
   while ((match = kMarkupPattern.exec(data))) {

--- a/src/third_party/html-parser/html-parser.ts
+++ b/src/third_party/html-parser/html-parser.ts
@@ -114,7 +114,8 @@ export function parse(data: string, rootElement: Element) {
       // not </ tags
       if (!endSlash && kElementsClosedByOpening[currentParent.tagName]) {
         if (kElementsClosedByOpening[currentParent.tagName][normalizedTagName]) {
-          tagsClosed.push(currentParent.tagName);
+          stack.pop();
+          currentParent = arr_back(stack);
         }
       }
       const childToAppend = 


### PR DESCRIPTION
- When parsing html, change the element wrapping the content from a `<div>` to a `<q>`, which will not close any other tag automatically.
- Fixes #372 
- Fix test that failed after changing this behavior (was wrongly phrased in the first place).

@choumx @jridgewell 
cc/ @fstanis 