### PR TITLE
Enable value setter for HTMLSelectElement

### DIFF
--- a/src/test/htmloptionelement/value.ts
+++ b/src/test/htmloptionelement/value.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import anyTest, { TestInterface } from 'ava';
+import { HTMLOptionElement } from '../../worker-thread/dom/HTMLOptionElement';
+import { createDocument, Document } from '../../worker-thread/dom/Document';
+
+const test = anyTest as TestInterface<{
+  document: Document;
+  option: HTMLOptionElement;
+}>;
+
+test.beforeEach(t => {
+  const document = createDocument();
+  const option = document.createElement('option') as HTMLOptionElement;
+
+  t.context = {
+    document,
+    option,
+  };
+});
+
+test('value should be an empty string by default', t => {
+  const { option } = t.context;
+
+  t.is(option.value, '');
+});
+
+test('value should be settable with string coercion', t => {
+  const { option } = t.context;
+
+  option.value = '1931';
+  t.is(option.value, '1931');
+
+  option.value = 1930;
+  t.is(option.value, '1930');
+
+  option.value = false;
+  t.is(option.value, 'false');
+
+  option.value = null;
+  t.is(option.value, 'null');
+});

--- a/src/test/htmlselectelement/options.ts
+++ b/src/test/htmlselectelement/options.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import anyTest, { TestInterface } from 'ava';
+import { createDocument, Document } from '../../worker-thread/dom/Document';
+import { HTMLSelectElement } from '../../worker-thread/dom/HTMLSelectElement';
+import { HTMLOptionElement } from '../../worker-thread/dom/HTMLOptionElement';
+
+const test = anyTest as TestInterface<{
+  document: Document;
+  select: HTMLSelectElement;
+}>;
+
+test.beforeEach(t => {
+  const document = createDocument();
+  const select = document.createElement('select') as HTMLSelectElement;
+
+  t.context = {
+    document,
+    select,
+  };
+});
+
+test('options returns empty array by default', t => {
+  const { select } = t.context;
+
+  t.deepEqual(select.options, []);
+});
+
+test('options returns singular array for single option child', t => {
+  const { document, select } = t.context;
+  const option = document.createElement('option') as HTMLOptionElement;
+
+  select.appendChild(option);
+
+  t.deepEqual(select.options, [option]);
+});
+
+test('options returns array for multiple option child', t => {
+  const { document, select } = t.context;
+  const option = document.createElement('option') as HTMLOptionElement;
+  const optionTwo = document.createElement('option') as HTMLOptionElement;
+
+  select.appendChild(option);
+  select.appendChild(optionTwo);
+
+  t.deepEqual(select.options, [option, optionTwo]);
+});
+
+test('options returns ordered array for multiple option child', t => {
+  const { document, select } = t.context;
+  const option = document.createElement('option') as HTMLOptionElement;
+  const optionTwo = document.createElement('option') as HTMLOptionElement;
+
+  select.appendChild(option);
+  select.appendChild(optionTwo);
+  select.removeChild(option);
+  select.appendChild(option);
+
+  t.deepEqual(select.options, [optionTwo, option]);
+});

--- a/src/test/htmlselectelement/value.ts
+++ b/src/test/htmlselectelement/value.ts
@@ -40,7 +40,7 @@ test('value should be an empty string by default', t => {
   t.is(select.value, '');
 });
 
-test('value be settable with string coercion', t => {
+test('value should be settable with string coercion', t => {
   const { document, select } = t.context;
   const option = document.createElement('option') as HTMLOptionElement;
   const optionTwo = document.createElement('option') as HTMLOptionElement;
@@ -54,6 +54,39 @@ test('value be settable with string coercion', t => {
   t.is(select.value, '1931');
   t.is(option.selected, false);
   t.is(optionTwo.selected, true);
+});
+
+test('singular select: value should be settable to invalid value', t => {
+  const { document, select } = t.context;
+  const option = document.createElement('option') as HTMLOptionElement;
+  const optionTwo = document.createElement('option') as HTMLOptionElement;
+
+  option.value = '1930';
+  optionTwo.value = '1931';
+  select.appendChild(option);
+  select.appendChild(optionTwo);
+  select.value = 'foo';
+
+  t.is(select.value, '');
+  t.is(option.selected, false);
+  t.is(optionTwo.selected, false);
+});
+
+test('multiple select: value should be settable to invalid value', t => {
+  const { document, select } = t.context;
+  select.multiple = true;
+  const option = document.createElement('option') as HTMLOptionElement;
+  const optionTwo = document.createElement('option') as HTMLOptionElement;
+
+  option.value = '1930';
+  optionTwo.value = '1931';
+  select.appendChild(option);
+  select.appendChild(optionTwo);
+  select.value = 'foo';
+
+  t.is(select.value, '');
+  t.is(option.selected, false);
+  t.is(optionTwo.selected, false);
 });
 
 test('singular select: value should become the only option appended', t => {

--- a/src/test/htmlselectelement/value.ts
+++ b/src/test/htmlselectelement/value.ts
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import anyTest, { TestInterface } from 'ava';
+import { HTMLOptionElement } from '../../worker-thread/dom/HTMLOptionElement';
+import { createDocument, Document } from '../../worker-thread/dom/Document';
+import { HTMLSelectElement } from '../../worker-thread/dom/HTMLSelectElement';
+
+const test = anyTest as TestInterface<{
+  document: Document;
+  select: HTMLSelectElement;
+}>;
+
+test.beforeEach(t => {
+  const document = createDocument();
+  const select = document.createElement('select') as HTMLSelectElement;
+
+  t.context = {
+    document,
+    select,
+  };
+});
+
+test('value should be an empty string by default', t => {
+  const { select } = t.context;
+
+  t.is(select.value, '');
+});
+
+test('value be settable with string coercion', t => {
+  const { document, select } = t.context;
+  const option = document.createElement('option') as HTMLOptionElement;
+  const optionTwo = document.createElement('option') as HTMLOptionElement;
+
+  option.value = '1930';
+  optionTwo.value = '1931';
+  select.appendChild(option);
+  select.appendChild(optionTwo);
+  select.value = 1931;
+
+  t.is(select.value, '1931');
+  t.is(option.selected, false);
+  t.is(optionTwo.selected, true);
+});
+
+test('singular select: value should become the only option appended', t => {
+  const { document, select } = t.context;
+  const option = document.createElement('option') as HTMLOptionElement;
+
+  option.value = '1930';
+  select.appendChild(option);
+
+  t.is(select.value, '1930');
+  t.is(option.selected, true);
+});
+
+test('multiple select: value should become the only option appended', t => {
+  const { document, select } = t.context;
+  select.multiple = true;
+  const option = document.createElement('option') as HTMLOptionElement;
+
+  option.value = '1930';
+  select.appendChild(option);
+
+  t.is(select.value, '1930');
+  t.is(option.selected, true);
+});
+
+test('singular select: value should become the first of many options appended', t => {
+  const { document, select } = t.context;
+  const option = document.createElement('option') as HTMLOptionElement;
+  const optionTwo = document.createElement('option') as HTMLOptionElement;
+
+  option.value = '1930';
+  optionTwo.value = '1931';
+  select.appendChild(option);
+  select.appendChild(optionTwo);
+
+  t.is(select.value, '1930');
+  t.is(option.selected, true);
+  t.is(optionTwo.selected, false);
+});
+
+test('multiple select: value should become the first of many options appended', t => {
+  const { document, select } = t.context;
+  select.multiple = true;
+  const option = document.createElement('option') as HTMLOptionElement;
+  const optionTwo = document.createElement('option') as HTMLOptionElement;
+
+  option.value = '1930';
+  optionTwo.value = '1931';
+  select.appendChild(option);
+  select.appendChild(optionTwo);
+
+  t.is(select.value, '1930');
+  t.is(option.selected, true);
+  t.is(optionTwo.selected, false);
+});
+
+test('singular select: value should be overwritten by pre-selected option appended', t => {
+  const { document, select } = t.context;
+  const option = document.createElement('option') as HTMLOptionElement;
+  const optionTwo = document.createElement('option') as HTMLOptionElement;
+
+  option.value = '1930';
+  optionTwo.value = '1931';
+  optionTwo.selected = true;
+  select.appendChild(option);
+  select.appendChild(optionTwo);
+
+  t.is(select.value, '1931');
+  t.is(option.selected, false);
+  t.is(optionTwo.selected, true);
+});
+
+test('multiple select: value should not be overwritten by pre-selected option appended', t => {
+  const { document, select } = t.context;
+  select.multiple = true;
+  const option = document.createElement('option') as HTMLOptionElement;
+  const optionTwo = document.createElement('option') as HTMLOptionElement;
+
+  option.value = '1930';
+  optionTwo.value = '1931';
+  optionTwo.selected = true;
+  select.appendChild(option);
+  select.appendChild(optionTwo);
+
+  t.is(select.value, '1930');
+  t.is(option.selected, true);
+  t.is(optionTwo.selected, true);
+});
+
+test('single select: value should be default when only option removed', t => {
+  const { document, select } = t.context;
+  const option = document.createElement('option') as HTMLOptionElement;
+
+  option.value = '1930';
+  select.appendChild(option);
+  select.removeChild(option);
+
+  t.is(select.value, '');
+  t.is(option.selected, true);
+});
+
+test('multiple select: value should be default when only option removed', t => {
+  const { document, select } = t.context;
+  select.multiple = true;
+  const option = document.createElement('option') as HTMLOptionElement;
+
+  option.value = '1930';
+  select.appendChild(option);
+  select.removeChild(option);
+
+  t.is(select.value, '');
+  t.is(option.selected, true);
+});
+
+test('single select: value should be first option when selected value removed.', t => {
+  const { document, select } = t.context;
+  const option = document.createElement('option') as HTMLOptionElement;
+  const optionTwo = document.createElement('option') as HTMLOptionElement;
+
+  option.value = '1930';
+  optionTwo.value = '1931';
+  select.appendChild(option);
+  select.appendChild(optionTwo);
+  select.removeChild(option);
+
+  t.is(select.value, '1931');
+  t.is(option.selected, true);
+  t.is(optionTwo.selected, true);
+});
+
+test('multple select: value should become the default when selected value removed.', t => {
+  const { document, select } = t.context;
+  select.multiple = true;
+  const option = document.createElement('option') as HTMLOptionElement;
+  const optionTwo = document.createElement('option') as HTMLOptionElement;
+
+  option.value = '1930';
+  optionTwo.value = '1931';
+  select.appendChild(option);
+  select.appendChild(optionTwo);
+  select.removeChild(option);
+
+  t.is(select.value, '');
+  t.is(option.selected, true);
+  t.is(optionTwo.selected, false);
+});

--- a/src/transfer/TransferrableKeys.ts
+++ b/src/transfer/TransferrableKeys.ts
@@ -71,4 +71,6 @@ export const enum TransferrableKeys {
   command = 53,
   phase = 54,
   worker = 55,
+  insertedNode = 56,
+  removedNode = 57,
 }

--- a/src/worker-thread/dom/HTMLOptionElement.ts
+++ b/src/worker-thread/dom/HTMLOptionElement.ts
@@ -106,7 +106,7 @@ export class HTMLOptionElement extends HTMLElement {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement
    * @return value attribute value or text content if there is no attribute.
    */
-  get value(): string {
+  get value(): any {
     return this.getAttribute('value') || this.textContent;
   }
 
@@ -114,7 +114,7 @@ export class HTMLOptionElement extends HTMLElement {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement
    * @param value new value for an option element.
    */
-  set value(value: string) {
+  set value(value: any) {
     this.setAttribute('value', value);
   }
 }

--- a/src/worker-thread/dom/HTMLSelectElement.ts
+++ b/src/worker-thread/dom/HTMLSelectElement.ts
@@ -21,9 +21,10 @@ import { HTMLInputLabelsMixin } from './HTMLInputLabelsMixin';
 import { matchChildrenElements, matchChildElement, tagNameConditionPredicate } from './matchElements';
 import { HTMLOptionElement } from './HTMLOptionElement';
 import { TransferrableKeys } from '../../transfer/TransferrableKeys';
+import { Node } from './Node';
 
 const isOptionPredicate = tagNameConditionPredicate(['OPTION']);
-const isSelectedOptionPredicate = (element: Element): boolean => element.tagName === 'OPTION' && (element as HTMLOptionElement).selected === true;
+const isSelectedOptionPredicate = (element: Element): boolean => isOptionPredicate(element) && (element as HTMLOptionElement).selected === true;
 
 const enum SizeDefaults {
   SINGLE = 1,
@@ -40,11 +41,43 @@ export class HTMLSelectElement extends HTMLElement {
   private [TransferrableKeys.size]: number = SizeDefaults.UNMODIFIED;
 
   /**
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/length
+   * Extend functionality after child insertion to make sure the correct option is selected.
+   * @param child
+   */
+  protected [TransferrableKeys.insertedNode](child: Node): void {
+    super[TransferrableKeys.insertedNode](child);
+
+    // When this singular value select is appending a child, set the value property for two cases.
+    // 1. The inserted child is already selected.
+    // 2. The current value of the select is the default ('').
+    if ((!this.multiple && (isOptionPredicate(child as Element) && child.selected)) || this.value === '') {
+      this.value = child.value;
+    }
+  }
+
+  /**
+   * Extend functionality after child insertion to make sure the correct option is selected.
+   * @param child
+   */
+  protected [TransferrableKeys.removedNode](child: Node): void {
+    super[TransferrableKeys.removedNode](child);
+
+    // When this singular value select is removing a selected child
+    // ... set the value property to the first valid option.
+    if (!this.multiple && child.selected) {
+      const options = this.options;
+      if (options.length > 0) {
+        this.value = options[0].value;
+      }
+    }
+  }
+
+  /**
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/length
    * @return number of controls in the form
    */
   get length(): number {
-    return matchChildrenElements(this, isOptionPredicate).length;
+    return this.options.length;
   }
 
   /**
@@ -118,9 +151,18 @@ export class HTMLSelectElement extends HTMLElement {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement
    * @return the value of the first selected option
    */
-  get value(): string {
+  get value(): any {
     const firstSelectedChild = matchChildElement(this, isSelectedOptionPredicate);
     return firstSelectedChild ? (firstSelectedChild as HTMLOptionElement).value : '';
+  }
+
+  /**
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement
+   * @set value
+   */
+  set value(value: any) {
+    const stringValue = String(value);
+    this.children.forEach((element: Element) => isOptionPredicate(element) && (element.selected = element.value === stringValue));
   }
 }
 registerSubclass('select', HTMLSelectElement);

--- a/src/worker-thread/dom/Node.ts
+++ b/src/worker-thread/dom/Node.ts
@@ -207,9 +207,8 @@ export abstract class Node {
 
       // Removing a child can cause this.childNodes to change, meaning we need to splice from its updated location.
       this.childNodes.splice(this.childNodes.indexOf(referenceNode), 0, child);
-      child.parentNode = this;
-      propagate(child, 'isConnected', this.isConnected);
-      propagate(child, TransferrableKeys.scopingRoot, this[TransferrableKeys.scopingRoot]);
+      this[TransferrableKeys.insertedNode](child);
+
       mutate(
         this.ownerDocument as Document,
         {
@@ -229,23 +228,30 @@ export abstract class Node {
         ],
       );
 
-      /*
-      [
-        TransferrableMutationType.CHILD_LIST,
-        Target.index,
-        NextSibling.index,
-        PreviousSibling.index,
-        AppendedNodeCount,
-        RemovedNodeCount,
-        ... AppendedNode.index,
-        ... RemovedNode.index,
-      ]
-      */
-
       return child;
     }
 
     return null;
+  }
+
+  /**
+   * When a Node is inserted, this method is called (and can be extended by other classes)
+   * @param child
+   */
+  protected [TransferrableKeys.insertedNode](child: Node): void {
+    child.parentNode = this;
+    propagate(child, 'isConnected', this.isConnected);
+    propagate(child, TransferrableKeys.scopingRoot, this[TransferrableKeys.scopingRoot]);
+  }
+
+  /**
+   * When a node is removed, this method is called (and can be extended by other classes)
+   * @param child
+   */
+  protected [TransferrableKeys.removedNode](child: Node): void {
+    child.parentNode = null;
+    propagate(child, 'isConnected', false);
+    propagate(child, TransferrableKeys.scopingRoot, child);
   }
 
   /**
@@ -259,10 +265,8 @@ export abstract class Node {
       child.childNodes.slice().forEach(this.appendChild, this);
     } else {
       child.remove();
-      child.parentNode = this;
-      propagate(child, 'isConnected', this.isConnected);
-      propagate(child, TransferrableKeys.scopingRoot, this[TransferrableKeys.scopingRoot]);
       this.childNodes.push(child);
+      this[TransferrableKeys.insertedNode](child);
 
       const previousSibling = this.childNodes[this.childNodes.length - 2];
       mutate(
@@ -298,10 +302,9 @@ export abstract class Node {
     const exists = index >= 0;
 
     if (exists) {
-      child.parentNode = null;
-      propagate(child, 'isConnected', false);
-      propagate(child, TransferrableKeys.scopingRoot, child);
       this.childNodes.splice(index, 1);
+      this[TransferrableKeys.removedNode](child);
+
       mutate(
         this.ownerDocument as Document,
         {
@@ -340,16 +343,10 @@ export abstract class Node {
     // per replaceChild() call.
     newChild.remove();
 
-    oldChild.parentNode = null;
-    propagate(oldChild, 'isConnected', false);
-    propagate(oldChild, TransferrableKeys.scopingRoot, oldChild);
-
     const index = this.childNodes.indexOf(oldChild);
     this.childNodes.splice(index, 1, newChild);
-
-    newChild.parentNode = this;
-    propagate(newChild, 'isConnected', this.isConnected);
-    propagate(newChild, TransferrableKeys.scopingRoot, this[TransferrableKeys.scopingRoot]);
+    this[TransferrableKeys.removedNode](oldChild);
+    this[TransferrableKeys.insertedNode](newChild);
 
     mutate(
       this.ownerDocument as Document,


### PR DESCRIPTION
`HTMLSelectElement.set value` wasn't implemented, and is needed for a demo I am working on.

This PR changes `Node` to allow for a new method that runs after insertion or removal, but before the microtask collection in `MutationObserver`. This lets extensions of `Node` like `HTMLSelectElement` update local information on each insertion/removal.