### PR TITLE
Ivar sync updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     {
       "path": "./dist/worker.mjs",
       "compression": "brotli",
-      "maxSize": "8.2 kB"
+      "maxSize": "8.3 kB"
     },
     {
       "path": "./dist/worker.safe.mjs",

--- a/src/transfer/TransferrableKeys.ts
+++ b/src/transfer/TransferrableKeys.ts
@@ -73,4 +73,5 @@ export const enum TransferrableKeys {
   worker = 55,
   insertedNode = 56,
   removedNode = 57,
+  allowTransfer = 58,
 }

--- a/src/worker-thread/MutationObserver.ts
+++ b/src/worker-thread/MutationObserver.ts
@@ -44,7 +44,7 @@ const pushMutation = (observer: MutationObserver, record: MutationRecord): void 
  * @param record MutationRecord to push into MutationObservers.
  */
 export function mutate(document: Document, record: MutationRecord, transferable: Array<number>): void {
-  transfer(document.postMessage, transferable);
+  transfer(document, transferable);
 
   observers.forEach(observer => {
     let target: Node | null = record.target;

--- a/src/worker-thread/MutationTransfer.ts
+++ b/src/worker-thread/MutationTransfer.ts
@@ -21,14 +21,14 @@ import { TransferrableKeys } from '../transfer/TransferrableKeys';
 import { Node } from './dom/Node';
 import { Phase } from '../transfer/Phase';
 import { phase, set as setPhase } from './phase';
-import { PostMessage } from './worker-thread';
+import { Document } from './dom/Document';
 
 let allowTransfer = false;
 let pending = false;
 let pendingMutations: Array<number> = [];
 
-export function transfer(postMessage: PostMessage, mutation: Array<number>): void {
-  if (phase > Phase.Hydrating) {
+export function transfer(document: Document, mutation: Array<number>): void {
+  if (phase > Phase.Hydrating && document[TransferrableKeys.allowTransfer]) {
     pending = true;
     pendingMutations = pendingMutations.concat(mutation);
 
@@ -40,7 +40,7 @@ export function transfer(postMessage: PostMessage, mutation: Array<number>): voi
           ).buffer;
           const mutations = new Uint16Array(pendingMutations).buffer;
 
-          postMessage(
+          document.postMessage(
             {
               [TransferrableKeys.type]: MessageType.MUTATE,
               [TransferrableKeys.nodes]: nodes,

--- a/src/worker-thread/SyncValuePropagation.ts
+++ b/src/worker-thread/SyncValuePropagation.ts
@@ -17,6 +17,7 @@
 import { MessageToWorker, MessageType, ValueSyncToWorker } from '../transfer/Messages';
 import { TransferrableKeys } from '../transfer/TransferrableKeys';
 import { get } from './nodes';
+import { Document } from './dom/Document';
 
 /**
  * When an event is dispatched from the main thread, it needs to be propagated in the worker thread.
@@ -35,8 +36,10 @@ export function propagate(): void {
     const sync = (data as ValueSyncToWorker)[TransferrableKeys.sync];
     const node = get(sync[TransferrableKeys.index]);
     if (node) {
+      (node.ownerDocument as Document)[TransferrableKeys.allowTransfer] = false;
       // Modify the private backing ivar of `value` property to avoid mutation/sync cycle.
-      node[TransferrableKeys.value] = sync[TransferrableKeys.value];
+      node.value = sync[TransferrableKeys.value];
+      (node.ownerDocument as Document)[TransferrableKeys.allowTransfer] = true;
     }
   });
 }

--- a/src/worker-thread/dom/Document.ts
+++ b/src/worker-thread/dom/Document.ts
@@ -59,6 +59,7 @@ import { observe } from '../MutationTransfer';
 import { NodeType, HTML_NAMESPACE } from '../../transfer/TransferrableNodes';
 import { propagate as propagateEvents } from '../Event';
 import { propagate as propagateSyncValues } from '../SyncValuePropagation';
+import { TransferrableKeys } from '../../transfer/TransferrableKeys';
 
 const DOCUMENT_NAME = '#document';
 
@@ -77,6 +78,7 @@ export class Document extends Element {
   public documentElement: Document;
   public body: Element;
   public postMessage: PostMessage;
+  public [TransferrableKeys.allowTransfer]: boolean = true;
 
   constructor() {
     super(NodeType.DOCUMENT_NODE, DOCUMENT_NAME, HTML_NAMESPACE, null);

--- a/src/worker-thread/dom/Element.ts
+++ b/src/worker-thread/dom/Element.ts
@@ -524,7 +524,7 @@ export class Element extends ParentNode {
         resolve(defaultValue);
       } else {
         addEventListener('message', messageHandler);
-        transfer((this.ownerDocument as Document).postMessage, [TransferrableMutationType.GET_BOUNDING_CLIENT_RECT, this[TransferrableKeys.index]]);
+        transfer(this.ownerDocument as Document, [TransferrableMutationType.GET_BOUNDING_CLIENT_RECT, this[TransferrableKeys.index]]);
         setTimeout(resolve, 500, defaultValue); // TODO: Why a magical constant, define and explain.
       }
     });

--- a/src/worker-thread/dom/HTMLInputElement.ts
+++ b/src/worker-thread/dom/HTMLInputElement.ts
@@ -48,7 +48,7 @@ export class HTMLInputElement extends HTMLElement {
     // Don't early-out if value doesn't appear to have changed.
     // The worker may have a stale value since 'input' events aren't being forwarded.
     this[TransferrableKeys.value] = String(value);
-    transfer((this.ownerDocument as Document).postMessage, [
+    transfer(this.ownerDocument as Document, [
       TransferrableMutationType.PROPERTIES,
       this[TransferrableKeys.index],
       storeString('value'),
@@ -97,7 +97,7 @@ export class HTMLInputElement extends HTMLElement {
       return;
     }
     this[TransferrableKeys.checked] = !!value;
-    transfer((this.ownerDocument as Document).postMessage, [
+    transfer(this.ownerDocument as Document, [
       TransferrableMutationType.PROPERTIES,
       this[TransferrableKeys.index],
       storeString('checked'),

--- a/src/worker-thread/dom/HTMLOptionElement.ts
+++ b/src/worker-thread/dom/HTMLOptionElement.ts
@@ -76,7 +76,7 @@ export class HTMLOptionElement extends HTMLElement {
    */
   set selected(value: any) {
     this[TransferrableKeys.selected] = !!value;
-    transfer((this.ownerDocument as Document).postMessage, [
+    transfer(this.ownerDocument as Document, [
       TransferrableMutationType.PROPERTIES,
       this[TransferrableKeys.index],
       storeString('selected'),

--- a/src/worker-thread/dom/Node.ts
+++ b/src/worker-thread/dom/Node.ts
@@ -397,14 +397,7 @@ export abstract class Node {
       this[TransferrableKeys.handlers][lowerType] = [handler];
     }
 
-    transfer((this.ownerDocument as Document).postMessage, [
-      TransferrableMutationType.EVENT_SUBSCRIPTION,
-      this[TransferrableKeys.index],
-      0,
-      1,
-      storedType,
-      index,
-    ]);
+    transfer(this.ownerDocument as Document, [TransferrableMutationType.EVENT_SUBSCRIPTION, this[TransferrableKeys.index], 0, 1, storedType, index]);
   }
 
   /**
@@ -420,7 +413,7 @@ export abstract class Node {
 
     if (index >= 0) {
       handlers.splice(index, 1);
-      transfer((this.ownerDocument as Document).postMessage, [
+      transfer(this.ownerDocument as Document, [
         TransferrableMutationType.EVENT_SUBSCRIPTION,
         this[TransferrableKeys.index],
         1,

--- a/src/worker-thread/long-task.ts
+++ b/src/worker-thread/long-task.ts
@@ -28,16 +28,16 @@ export function wrap(target: Node, func: Function): Function {
 
 function execute(target: Node, promise: Promise<any>): Promise<any> {
   // Start the task.
-  transfer((target.ownerDocument as Document).postMessage, [TransferrableMutationType.LONG_TASK_START, target[TransferrableKeys.index]]);
+  transfer(target.ownerDocument as Document, [TransferrableMutationType.LONG_TASK_START, target[TransferrableKeys.index]]);
   return promise.then(
     result => {
       // Complete the task.
-      transfer((target.ownerDocument as Document).postMessage, [TransferrableMutationType.LONG_TASK_END, target[TransferrableKeys.index]]);
+      transfer(target.ownerDocument as Document, [TransferrableMutationType.LONG_TASK_END, target[TransferrableKeys.index]]);
       return result;
     },
     reason => {
       // Complete the task.
-      transfer((target.ownerDocument as Document).postMessage, [TransferrableMutationType.LONG_TASK_END, target[TransferrableKeys.index]]);
+      transfer(target.ownerDocument as Document, [TransferrableMutationType.LONG_TASK_END, target[TransferrableKeys.index]]);
       throw reason;
     },
   );


### PR DESCRIPTION
Ordering of updates for events is crucial, and allows us to avoid the mutate/transfer cycle.

Since we've separated out `MutationObserver` from `MutationTransfer`, we can now safely apply sync value updates without triggering unintentional changes to attributes.