### PR TITLE
Correct regression with 0.4.0

### DIFF
--- a/src/main-thread/configuration.ts
+++ b/src/main-thread/configuration.ts
@@ -16,6 +16,7 @@
 
 import { MessageFromWorker, MessageToWorker } from '../transfer/Messages';
 import { Phase } from '../transfer/Phase';
+import { HydrateableNode } from '../transfer/TransferrableNodes';
 
 /**
  * The callback for `onMutationPump`. If specified, this callback will be called
@@ -41,9 +42,7 @@ export interface WorkerDOMConfiguration {
 
   // ---- Optional Callbacks
   // Called when worker consumes the page's initial DOM state.
-  onCreateWorker?: (initialDOM: RenderableElement) => void;
-  // Called when the worker is hydrated (sends a HYDRATE message).
-  onHydration?: () => void;
+  onCreateWorker?: (initialDOM: RenderableElement, strings: Array<string>, skeleton: HydrateableNode, keys: Array<string>) => void;
   // Called before a message is sent to the worker.
   onSendMessage?: (message: MessageToWorker) => void;
   // Called after a message is received from the worker.

--- a/src/main-thread/install.ts
+++ b/src/main-thread/install.ts
@@ -66,10 +66,6 @@ export function install(fetchPromise: Promise<[string, string]>, baseElement: HT
           new Uint16Array(data[TransferrableKeys.mutations]),
         );
 
-        // Invoke callbacks after hydrate/mutate processing so strings etc. are stored.
-        if (data[TransferrableKeys.type] === MessageType.HYDRATE && config.onHydration) {
-          config.onHydration();
-        }
         if (config.onReceiveMessage) {
           config.onReceiveMessage(message);
         }

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -79,7 +79,7 @@ export class WorkerContext {
       console.info('debug', 'hydratedNode', readableHydrateableRootNode(baseElement));
     }
     if (config.onCreateWorker) {
-      config.onCreateWorker(baseElement);
+      config.onCreateWorker(baseElement, strings, skeleton, keys);
     }
   }
 

--- a/src/worker-thread/dom/Document.ts
+++ b/src/worker-thread/dom/Document.ts
@@ -52,13 +52,14 @@ import { Comment } from './Comment';
 import { toLower } from '../../utils';
 import { DocumentFragment } from './DocumentFragment';
 import { PostMessage } from '../worker-thread';
-import { observe } from '../MutationTransfer';
 import { NodeType, HTML_NAMESPACE } from '../../transfer/TransferrableNodes';
+import { Phase } from '../../transfer/Phase';
 import { propagate as propagateEvents } from '../Event';
 import { propagate as propagateSyncValues } from '../SyncValuePropagation';
 import { propagate as propagateResize } from '../ResizePropagation';
 import { TransferrableKeys } from '../../transfer/TransferrableKeys';
 import { WorkerDOMGlobalScope, GlobalScope } from '../WorkerDOMGlobalScope';
+import { set as setPhase } from '../phase';
 
 const DOCUMENT_NAME = '#document';
 
@@ -84,7 +85,7 @@ export class Document extends Element {
 
   public observe = (): void => {
     // Sync Document Changes.
-    observe();
+    setPhase(Phase.Mutating);
     propagateEvents(this.defaultView);
     propagateSyncValues();
     propagateResize(this.defaultView);


### PR DESCRIPTION
There were two regressions with `0.4.0`. #410 

1. onHydrate from `WorkerDOMConfiguration` never fired. This was intentional, since the method no longer served its original purpose. It's been removed in this PR.

2. `phase` was not sent with mutations between threads. This has been fixed, and types have been tightened to prevent future regressions.

Please note: This will be released as `0.5.0`.