### PR TITLE
Remove Whitespace from Worker Template Literal 

### DIFF
--- a/config/rollup.main-thread.js
+++ b/config/rollup.main-thread.js
@@ -18,7 +18,7 @@ import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import { terser } from 'rollup-plugin-terser';
 import replace from 'rollup-plugin-replace';
 import copy from 'rollup-plugin-copy';
-import { babelPlugin, removeDebugCommandExecutors } from './rollup.plugins.js';
+import { babelPlugin, removeDebugCommandExecutors, removeWorkerWhitespace } from './rollup.plugins.js';
 
 const ESModules = [
   {
@@ -29,6 +29,7 @@ const ESModules = [
       sourcemap: true,
     },
     plugins: [
+      removeWorkerWhitespace(),
       removeDebugCommandExecutors(),
       replace({
         DEBUG_ENABLED: false,
@@ -49,6 +50,7 @@ const ESModules = [
       sourcemap: true,
     },
     plugins: [
+      removeWorkerWhitespace(),
       copy({
         targets: ['config/dist-packaging/debug/package.json'],
         outputFolder: 'dist/debug',
@@ -70,6 +72,7 @@ const ESModules = [
       sourcemap: true,
     },
     plugins: [
+      removeWorkerWhitespace(),
       copy({
         targets: ['config/dist-packaging/amp/package.json'],
         outputFolder: 'dist/amp',
@@ -95,6 +98,7 @@ const IIFEModules = [
       sourcemap: true,
     },
     plugins: [
+      removeWorkerWhitespace(),
       removeDebugCommandExecutors(),
       replace({
         DEBUG_ENABLED: false,
@@ -116,6 +120,7 @@ const IIFEModules = [
       sourcemap: true,
     },
     plugins: [
+      removeWorkerWhitespace(),
       replace({
         DEBUG_ENABLED: true,
       }),

--- a/config/rollup.plugins.js
+++ b/config/rollup.plugins.js
@@ -40,6 +40,9 @@ export function babelPlugin({ transpileToES5, allowConsole = false, allowPostMes
           targets,
           loose: transpileToES5 ? false : true,
           modules: false,
+          // Excluding 'transform-template-literals'... this library doesn't need caching for template literals.
+          // As a result, the Safari bug causing transforms here isn't material.
+          exclude: transpileToES5 ? [] : ['transform-template-literals'],
         },
       ],
     ],
@@ -90,7 +93,7 @@ export function removeDebugCommandExecutors() {
         .readdirSync(path.join(path.dirname(options.input), 'commands'))
         .filter(file => path.extname(file) !== '.map' && path.basename(file, '.js') !== 'interface').length;
     },
-    async renderChunk(code) {
+    renderChunk(code) {
       const source = new MagicString(code);
       const program = context.parse(code, { ranges: true });
 
@@ -118,6 +121,35 @@ export function removeDebugCommandExecutors() {
       if (toDiscover > 0) {
         context.warn(`${toDiscover} CommandExecutors were not found during compilation.`);
       }
+
+      return {
+        code: source.toString(),
+        map: source.generateMap(),
+      };
+    },
+  };
+}
+
+export function removeWorkerWhitespace() {
+  return {
+    name: 'remove-worker-whitespace',
+    transform(code) {
+      const source = new MagicString(code);
+      const program = this.parse(code, { ranges: true });
+
+      walk.simple(program, {
+        TemplateLiteral(node) {
+          let literalValue = code.substring(node.range[0], node.range[1]);
+          literalValue = literalValue
+            .replace(/\) \{/g, '){')
+            .replace(/, /g, ',')
+            .replace(/ = /g, '=')
+            .replace(/\t/g, '')
+            .replace(/[ ]{2,}/g, '')
+            .replace(/\n/g, '');
+          source.overwrite(node.range[0], node.range[1], literalValue);
+        },
+      });
 
       return {
         code: source.toString(),

--- a/config/rollup.plugins.js
+++ b/config/rollup.plugins.js
@@ -40,9 +40,6 @@ export function babelPlugin({ transpileToES5, allowConsole = false, allowPostMes
           targets,
           loose: transpileToES5 ? false : true,
           modules: false,
-          // Excluding 'transform-template-literals'... this library doesn't need caching for template literals.
-          // As a result, the Safari bug causing transforms here isn't material.
-          exclude: transpileToES5 ? [] : ['transform-template-literals'],
         },
       ],
     ],


### PR DESCRIPTION
Worker source template literal contained newlines and extraneous spaces.

This is not an attempt to use a minifier on its source, but rather a small number of safe reductions in character count.