### PR TITLE
Define property-backed attributes on the class constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     {
       "path": "./dist/worker/worker.mjs",
       "compression": "brotli",
-      "maxSize": "8.4 kB"
+      "maxSize": "8.5 kB"
     },
     {
       "path": "./dist/worker/worker.js",

--- a/src/worker-thread/css/CSSStyleDeclaration.ts
+++ b/src/worker-thread/css/CSSStyleDeclaration.ts
@@ -96,10 +96,6 @@ export class CSSStyleDeclaration implements StyleDeclaration {
   constructor(target: Element) {
     this[TransferrableKeys.storeAttribute] = target[TransferrableKeys.storeAttribute].bind(target);
     this[TransferrableKeys.target] = target;
-
-    if (target && target[TransferrableKeys.propertyBackedAttributes]) {
-      target[TransferrableKeys.propertyBackedAttributes].style = [(): string | null => this.cssText, (value: string) => (this.cssText = value)];
-    }
   }
 
   /**

--- a/src/worker-thread/dom/DOMTokenList.ts
+++ b/src/worker-thread/dom/DOMTokenList.ts
@@ -42,9 +42,7 @@ export class DOMTokenList {
   constructor(defineOn: typeof Element, target: Element, attributeName: string, accessorKey: string | null, propertyName: string | null) {
     this[TransferrableKeys.target] = target;
     this[TransferrableKeys.attributeName] = attributeName;
-
     this[TransferrableKeys.storeAttribute] = target[TransferrableKeys.storeAttribute].bind(target);
-    target[TransferrableKeys.propertyBackedAttributes][attributeName] = [(): string | null => this.value, (value: string) => (this.value = value)];
 
     if (accessorKey && propertyName) {
       Object.defineProperty(defineOn.prototype, propertyName, {

--- a/src/worker-thread/dom/HTMLAnchorElement.ts
+++ b/src/worker-thread/dom/HTMLAnchorElement.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { registerSubclass } from './Element';
+import { registerSubclass, definePropertyBackedAttributes } from './Element';
 import { HTMLElement } from './HTMLElement';
 import { DOMTokenList } from './DOMTokenList';
 import { reflectProperties } from './enhanceElement';
@@ -50,6 +50,9 @@ export class HTMLAnchorElement extends HTMLElement {
   }
 }
 registerSubclass('a', HTMLAnchorElement);
+definePropertyBackedAttributes(HTMLAnchorElement, {
+  rel: [(el): string | null => el.relList.value, (el, value: string) => (el.relList.value = value)],
+});
 
 // Reflected properties, strings.
 // HTMLAnchorElement.href => string, reflected attribute

--- a/src/worker-thread/dom/HTMLIFrameElement.ts
+++ b/src/worker-thread/dom/HTMLIFrameElement.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { registerSubclass } from './Element';
+import { registerSubclass, definePropertyBackedAttributes } from './Element';
 import { HTMLElement } from './HTMLElement';
 import { reflectProperties } from './enhanceElement';
 import { DOMTokenList } from './DOMTokenList';
@@ -24,7 +24,9 @@ export class HTMLIFrameElement extends HTMLElement {
   public sandbox: DOMTokenList = new DOMTokenList(HTMLIFrameElement, this, 'sandbox', null, null);
 }
 registerSubclass('iframe', HTMLIFrameElement);
-
+definePropertyBackedAttributes(HTMLIFrameElement, {
+  sandbox: [(el): string | null => el.sandbox.value, (el, value: string) => (el.sandbox.value = value)],
+});
 // Reflected properties
 // HTMLIFrameElement.allow => string, reflected attribute
 // HTMLIFrameElement.allowFullscreen => boolean, reflected attribute

--- a/src/worker-thread/dom/HTMLLinkElement.ts
+++ b/src/worker-thread/dom/HTMLLinkElement.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { registerSubclass } from './Element';
+import { registerSubclass, definePropertyBackedAttributes } from './Element';
 import { HTMLElement } from './HTMLElement';
 import { reflectProperties } from './enhanceElement';
 import { DOMTokenList } from './DOMTokenList';
@@ -23,6 +23,9 @@ export class HTMLLinkElement extends HTMLElement {
   public relList: DOMTokenList = new DOMTokenList(HTMLLinkElement, this, 'rel', 'relList', 'rel');
 }
 registerSubclass('link', HTMLLinkElement);
+definePropertyBackedAttributes(HTMLLinkElement, {
+  rel: [(el): string | null => el.relList.value, (el, value: string) => (el.relList.value = value)],
+});
 
 // Reflected Properties
 // HTMLLinkElement.as => string, reflected attribute

--- a/src/worker-thread/dom/HTMLOptionElement.ts
+++ b/src/worker-thread/dom/HTMLOptionElement.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import { registerSubclass } from './Element';
+import { registerSubclass, definePropertyBackedAttributes } from './Element';
 import { HTMLElement } from './HTMLElement';
 import { reflectProperties } from './enhanceElement';
-import { NodeName, NamespaceURI, Node } from './Node';
-import { NodeType } from '../../transfer/TransferrableNodes';
 import { TransferrableKeys } from '../../transfer/TransferrableKeys';
 import { transfer } from '../MutationTransfer';
 import { Document } from './Document';
@@ -28,16 +26,6 @@ import { NumericBoolean } from '../../utils';
 
 export class HTMLOptionElement extends HTMLElement {
   private [TransferrableKeys.selected]: boolean = false;
-
-  constructor(nodeType: NodeType, localName: NodeName, namespaceURI: NamespaceURI, ownerDocument: Node) {
-    super(nodeType, localName, namespaceURI, ownerDocument);
-
-    this[TransferrableKeys.propertyBackedAttributes].selected = [
-      (): string => String(this[TransferrableKeys.selected]),
-      (value: string): boolean => (this.selected = value === 'true'),
-    ];
-  }
-
   /**
    * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement
    * @return position of the option within the list of options it's within, or zero if there is no valid parent.
@@ -119,7 +107,9 @@ export class HTMLOptionElement extends HTMLElement {
   }
 }
 registerSubclass('option', HTMLOptionElement);
-
+definePropertyBackedAttributes(HTMLOptionElement, {
+  selected: [(el): string => String(el[TransferrableKeys.selected]), (el, value: string): boolean => (el.selected = value === 'true')],
+});
 // Reflected Properties
 // HTMLOptionElement.defaultSelected => boolean, reflected attribute
 // HTMLOptionElement.disabled => boolean, reflected attribute

--- a/src/worker-thread/dom/HTMLTableCellElement.ts
+++ b/src/worker-thread/dom/HTMLTableCellElement.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { registerSubclass } from './Element';
+import { registerSubclass, definePropertyBackedAttributes } from './Element';
 import { HTMLElement } from './HTMLElement';
 import { reflectProperties } from './enhanceElement';
 import { DOMTokenList } from './DOMTokenList';
@@ -34,6 +34,9 @@ export class HTMLTableCellElement extends HTMLElement {
 }
 registerSubclass('th', HTMLTableCellElement);
 registerSubclass('td', HTMLTableCellElement);
+definePropertyBackedAttributes(HTMLTableCellElement, {
+  headers: [(el): string | null => el.headers.value, (el, value: string) => (el.headers.value = value)],
+});
 
 // Reflected Properties
 // HTMLTableCellElement.abbr => string, reflected attribute


### PR DESCRIPTION
This should avoid allocating a `propertyBackedAttributes` object map for every element instance. Instead, the class defines how its property-backed attributes behaves.