### PR TITLE
Lazy initialize DOMTokenList

### DIFF
--- a/src/test/domtokenlist/add.test.ts
+++ b/src/test/domtokenlist/add.test.ts
@@ -15,7 +15,6 @@
  */
 
 import anyTest, { TestInterface } from 'ava';
-import { Element } from '../../worker-thread/dom/Element';
 import { DOMTokenList } from '../../worker-thread/dom/DOMTokenList';
 import { createTestingDocument } from '../DocumentCreation';
 
@@ -27,7 +26,7 @@ test.beforeEach(t => {
   const document = createTestingDocument();
 
   t.context = {
-    tokenList: new DOMTokenList(Element, document.createElement('div'), 'class', null, null),
+    tokenList: new DOMTokenList(document.createElement('div'), 'class'),
   };
 });
 

--- a/src/test/domtokenlist/contains.test.ts
+++ b/src/test/domtokenlist/contains.test.ts
@@ -15,7 +15,6 @@
  */
 
 import anyTest, { TestInterface } from 'ava';
-import { Element } from '../../worker-thread/dom/Element';
 import { DOMTokenList } from '../../worker-thread/dom/DOMTokenList';
 import { createTestingDocument } from '../DocumentCreation';
 
@@ -27,7 +26,7 @@ test.beforeEach(t => {
   const document = createTestingDocument();
 
   t.context = {
-    tokenList: new DOMTokenList(Element, document.createElement('div'), 'class', null, null),
+    tokenList: new DOMTokenList(document.createElement('div'), 'class'),
   };
 });
 

--- a/src/test/domtokenlist/item.test.ts
+++ b/src/test/domtokenlist/item.test.ts
@@ -15,7 +15,6 @@
  */
 
 import anyTest, { TestInterface } from 'ava';
-import { Element } from '../../worker-thread/dom/Element';
 import { DOMTokenList } from '../../worker-thread/dom/DOMTokenList';
 import { createTestingDocument } from '../DocumentCreation';
 
@@ -27,7 +26,7 @@ test.beforeEach(t => {
   const document = createTestingDocument();
 
   t.context = {
-    tokenList: new DOMTokenList(Element, document.createElement('div'), 'class', null, null),
+    tokenList: new DOMTokenList(document.createElement('div'), 'class'),
   };
 });
 

--- a/src/test/domtokenlist/remove.test.ts
+++ b/src/test/domtokenlist/remove.test.ts
@@ -15,7 +15,6 @@
  */
 
 import anyTest, { TestInterface } from 'ava';
-import { Element } from '../../worker-thread/dom/Element';
 import { DOMTokenList } from '../../worker-thread/dom/DOMTokenList';
 import { createTestingDocument } from '../DocumentCreation';
 
@@ -27,7 +26,7 @@ test.beforeEach(t => {
   const document = createTestingDocument();
 
   t.context = {
-    tokenList: new DOMTokenList(Element, document.createElement('div'), 'class', null, null),
+    tokenList: new DOMTokenList(document.createElement('div'), 'class'),
   };
 });
 

--- a/src/test/domtokenlist/replace.test.ts
+++ b/src/test/domtokenlist/replace.test.ts
@@ -15,7 +15,6 @@
  */
 
 import anyTest, { TestInterface } from 'ava';
-import { Element } from '../../worker-thread/dom/Element';
 import { DOMTokenList } from '../../worker-thread/dom/DOMTokenList';
 import { createTestingDocument } from '../DocumentCreation';
 
@@ -27,7 +26,7 @@ test.beforeEach(t => {
   const document = createTestingDocument();
 
   t.context = {
-    tokenList: new DOMTokenList(Element, document.createElement('div'), 'class', null, null),
+    tokenList: new DOMTokenList(document.createElement('div'), 'class'),
   };
 });
 

--- a/src/test/domtokenlist/toggle.test.ts
+++ b/src/test/domtokenlist/toggle.test.ts
@@ -15,7 +15,6 @@
  */
 
 import anyTest, { TestInterface } from 'ava';
-import { Element } from '../../worker-thread/dom/Element';
 import { DOMTokenList } from '../../worker-thread/dom/DOMTokenList';
 import { createTestingDocument } from '../DocumentCreation';
 
@@ -27,7 +26,7 @@ test.beforeEach(t => {
   const document = createTestingDocument();
 
   t.context = {
-    tokenList: new DOMTokenList(Element, document.createElement('div'), 'class', null, null),
+    tokenList: new DOMTokenList(document.createElement('div'), 'class'),
   };
 });
 

--- a/src/test/domtokenlist/value.test.ts
+++ b/src/test/domtokenlist/value.test.ts
@@ -15,7 +15,6 @@
  */
 
 import anyTest, { TestInterface } from 'ava';
-import { Element } from '../../worker-thread/dom/Element';
 import { DOMTokenList } from '../../worker-thread/dom/DOMTokenList';
 import { createTestingDocument } from '../DocumentCreation';
 
@@ -27,7 +26,7 @@ test.beforeEach(t => {
   const document = createTestingDocument();
 
   t.context = {
-    tokenList: new DOMTokenList(Element, document.createElement('div'), 'class', null, null),
+    tokenList: new DOMTokenList(document.createElement('div'), 'class'),
   };
 });
 

--- a/src/worker-thread/dom/DOMTokenList.ts
+++ b/src/worker-thread/dom/DOMTokenList.ts
@@ -23,6 +23,25 @@ import { TransferrableMutationType } from '../../transfer/TransferrableMutation'
 import { store as storeString } from '../strings';
 import { Document } from './Document';
 
+/**
+ * Synchronizes the string getter/setter with the actual DOMTokenList instance.
+ * @param defineOn Element or class extension to define getter/setter pair for token list access.
+ * @param accessorKey Key used to access DOMTokenList directly from specific element.
+ * @param propertyName Key used to access DOMTokenList as string getter/setter.
+ */
+export function synchronizedAccessor(defineOn: typeof Element, accessorKey: string, propertyName: string) {
+  Object.defineProperty(defineOn.prototype, propertyName, {
+    enumerable: true,
+    configurable: true,
+    get(): string {
+      return (this as Element)[accessorKey].value;
+    },
+    set(value: string) {
+      (this as Element)[accessorKey].value = value;
+    },
+  });
+}
+
 export class DOMTokenList {
   private [TransferrableKeys.tokens]: Array<string> = [];
   private [TransferrableKeys.target]: Element;
@@ -33,29 +52,13 @@ export class DOMTokenList {
    * The DOMTokenList interface represents a set of space-separated tokens.
    * It is indexed beginning with 0 as with JavaScript Array objects and is case-sensitive.
    * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList
-   * @param defineOn Element or class extension to define getter/setter pair for token list access.
    * @param target Specific Element instance to modify when value is changed.
    * @param attributeName Name of the attribute used by Element to access DOMTokenList.
-   * @param accessorKey Key used to access DOMTokenList directly from specific element.
-   * @param propertyName Key used to access DOMTokenList as string getter/setter.
    */
-  constructor(defineOn: typeof Element, target: Element, attributeName: string, accessorKey: string | null, propertyName: string | null) {
+  constructor(target: Element, attributeName: string) {
     this[TransferrableKeys.target] = target;
     this[TransferrableKeys.attributeName] = attributeName;
     this[TransferrableKeys.storeAttribute] = target[TransferrableKeys.storeAttribute].bind(target);
-
-    if (accessorKey && propertyName) {
-      Object.defineProperty(defineOn.prototype, propertyName, {
-        enumerable: true,
-        configurable: true,
-        get(): string {
-          return (this as Element)[accessorKey].value;
-        },
-        set(value: string) {
-          (this as Element)[accessorKey].value = value;
-        },
-      });
-    }
   }
 
   /**

--- a/src/worker-thread/dom/Element.ts
+++ b/src/worker-thread/dom/Element.ts
@@ -16,7 +16,7 @@
 
 import { Node, NodeName, NamespaceURI } from './Node';
 import { ParentNode } from './ParentNode';
-import { DOMTokenList } from './DOMTokenList';
+import { DOMTokenList, synchronizedAccessor } from './DOMTokenList';
 import { Attr, toString as attrsToString, matchPredicate as matchAttrPredicate } from './Attr';
 import { mutate } from '../MutationObserver';
 import { MutationRecordType } from '../MutationRecord';
@@ -84,6 +84,8 @@ enum ElementKind {
 const VOID_ELEMENTS: string[] = ['AREA', 'BASE', 'BR', 'COL', 'EMBED', 'HR', 'IMG', 'INPUT', 'LINK', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR'];
 
 export class Element extends ParentNode {
+  private _classList: DOMTokenList;
+
   public static [TransferrableKeys.propertyBackedAttributes]: PropertyBackedAttributes = {
     class: [(el): string | null => el.classList.value, (el, value: string) => (el.classList.value = value)],
     style: [(el): string | null => el.cssText, (el, value: string) => (el.cssText = value)],
@@ -91,7 +93,6 @@ export class Element extends ParentNode {
 
   public localName: NodeName;
   public attributes: Attr[] = [];
-  public classList: DOMTokenList = new DOMTokenList(Element, this, 'class', 'classList', 'className');
   public style: CSSStyleDeclaration = new CSSStyleDeclaration(this);
   public namespaceURI: NamespaceURI;
 
@@ -541,5 +542,10 @@ export class Element extends ParentNode {
       }
     });
   }
+
+  public get classList(): DOMTokenList {
+    return this._classList || (this._classList = new DOMTokenList(this, 'class'));
+  }
 }
+synchronizedAccessor(Element, 'classList', 'className');
 reflectProperties([{ id: [''] }], Element);

--- a/src/worker-thread/dom/HTMLAnchorElement.ts
+++ b/src/worker-thread/dom/HTMLAnchorElement.ts
@@ -16,11 +16,15 @@
 
 import { registerSubclass, definePropertyBackedAttributes } from './Element';
 import { HTMLElement } from './HTMLElement';
-import { DOMTokenList } from './DOMTokenList';
+import { DOMTokenList, synchronizedAccessor } from './DOMTokenList';
 import { reflectProperties } from './enhanceElement';
 
 export class HTMLAnchorElement extends HTMLElement {
-  public relList: DOMTokenList = new DOMTokenList(HTMLAnchorElement, this, 'rel', 'relList', 'rel');
+  private _relList: DOMTokenList;
+
+  public get relList(): DOMTokenList {
+    return this._relList || (this._relList = new DOMTokenList(this, 'rel'));
+  }
 
   /**
    * Returns the href property/attribute value
@@ -53,6 +57,7 @@ registerSubclass('a', HTMLAnchorElement);
 definePropertyBackedAttributes(HTMLAnchorElement, {
   rel: [(el): string | null => el.relList.value, (el, value: string) => (el.relList.value = value)],
 });
+synchronizedAccessor(HTMLAnchorElement, 'relList', 'rel');
 
 // Reflected properties, strings.
 // HTMLAnchorElement.href => string, reflected attribute

--- a/src/worker-thread/dom/HTMLIFrameElement.ts
+++ b/src/worker-thread/dom/HTMLIFrameElement.ts
@@ -20,8 +20,12 @@ import { reflectProperties } from './enhanceElement';
 import { DOMTokenList } from './DOMTokenList';
 
 export class HTMLIFrameElement extends HTMLElement {
+  private _sandbox: DOMTokenList;
+
   // HTMLIFrameElement.sandbox, DOMTokenList, reflected attribute
-  public sandbox: DOMTokenList = new DOMTokenList(HTMLIFrameElement, this, 'sandbox', null, null);
+  public get sandbox(): DOMTokenList {
+    return this._sandbox || (this._sandbox = new DOMTokenList(this, 'sandbox'));
+  }
 }
 registerSubclass('iframe', HTMLIFrameElement);
 definePropertyBackedAttributes(HTMLIFrameElement, {

--- a/src/worker-thread/dom/HTMLLinkElement.ts
+++ b/src/worker-thread/dom/HTMLLinkElement.ts
@@ -17,15 +17,20 @@
 import { registerSubclass, definePropertyBackedAttributes } from './Element';
 import { HTMLElement } from './HTMLElement';
 import { reflectProperties } from './enhanceElement';
-import { DOMTokenList } from './DOMTokenList';
+import { DOMTokenList, synchronizedAccessor } from './DOMTokenList';
 
 export class HTMLLinkElement extends HTMLElement {
-  public relList: DOMTokenList = new DOMTokenList(HTMLLinkElement, this, 'rel', 'relList', 'rel');
+  private _relList: DOMTokenList;
+
+  public get relList(): DOMTokenList {
+    return this._relList || (this._relList = new DOMTokenList(this, 'rel'));
+  }
 }
 registerSubclass('link', HTMLLinkElement);
 definePropertyBackedAttributes(HTMLLinkElement, {
   rel: [(el): string | null => el.relList.value, (el, value: string) => (el.relList.value = value)],
 });
+synchronizedAccessor(HTMLLinkElement, 'relList', 'rel');
 
 // Reflected Properties
 // HTMLLinkElement.as => string, reflected attribute

--- a/src/worker-thread/dom/HTMLTableCellElement.ts
+++ b/src/worker-thread/dom/HTMLTableCellElement.ts
@@ -21,7 +21,11 @@ import { DOMTokenList } from './DOMTokenList';
 import { matchNearestParent, tagNameConditionPredicate, matchChildrenElements } from './matchElements';
 
 export class HTMLTableCellElement extends HTMLElement {
-  public headers: DOMTokenList = new DOMTokenList(HTMLTableCellElement, this, 'headers', null, null);
+  private _headers: DOMTokenList;
+
+  public get headers(): DOMTokenList {
+    return this._headers || (this._headers = new DOMTokenList(this, 'headers'));
+  }
 
   /**
    * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableCellElement


### PR DESCRIPTION
Not every element is going to need its `DOMTokenList`s, so we shouldn't be initializing every one of them when the element itself is created.

This is part two of updating how `DOMTokenList` is synchronized across the threads. This optimization is work looking at independent of the final product, even if we don't choose to land the final sync work.

[Compare](https://github.com/jridgewell/worker-dom/compare/lazy-init-DOMTokenList...lazy-init-DOMTokenList-2) against https://github.com/ampproject/worker-dom/pull/471, since this PR includes #471's commits.