### PR TITLE
Clone SVG and other Elements with custom namespaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     {
       "path": "./dist/worker/worker.mjs",
       "compression": "brotli",
-      "maxSize": "10.3 kB"
+      "maxSize": "10.4 kB"
     },
     {
       "path": "./dist/worker/worker.js",

--- a/src/test/DocumentCreation.ts
+++ b/src/test/DocumentCreation.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { SVGElement } from '../worker-thread/dom/SVGElement';
 import { HTMLAnchorElement } from '../worker-thread/dom/HTMLAnchorElement';
 import { HTMLButtonElement } from '../worker-thread/dom/HTMLButtonElement';
 import { HTMLDataElement } from '../worker-thread/dom/HTMLDataElement';
@@ -88,6 +89,7 @@ const GlobalScope: GlobalScope = {
   innerHeight: 0,
   initialize: (document: Document, strings: Array<string>, hydrateableNode: HydrateableNode, keys: Array<string>) => void 0,
   MutationObserver,
+  SVGElement,
   HTMLAnchorElement,
   HTMLButtonElement,
   HTMLCanvasElement,

--- a/src/test/main-thread/offscreen-canvas.test.ts
+++ b/src/test/main-thread/offscreen-canvas.test.ts
@@ -116,8 +116,6 @@ test('method with string argument', t => {
 
   const textArg = 'textArg';
   const textArgIndex = storeString(strings, textArg);
-  console.log('textArgIndex: ' + textArgIndex);
-
   const actualArgs = [textArg, 1, 2];
   const passedArgs = [textArgIndex, 1, 2];
   const stub = createStub(context2d, methodName);

--- a/src/test/svgelement/cloneNode.test.ts
+++ b/src/test/svgelement/cloneNode.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import anyTest, { TestInterface } from 'ava';
+import { createTestingDocument } from '../DocumentCreation';
+import { Element } from '../../worker-thread/dom/Element';
+import { SVGElement } from '../../worker-thread/dom/SVGElement';
+import { TransferrableKeys } from '../../transfer/TransferrableKeys';
+import { SVG_NAMESPACE } from '../../transfer/TransferrableNodes';
+
+const test = anyTest as TestInterface<{
+  parent: Element;
+  svg: SVGElement;
+  path: Element;
+}>;
+
+test.beforeEach(t => {
+  const document = createTestingDocument();
+
+  t.context = {
+    parent: document.createElement('div'),
+    svg: document.createElementNS(SVG_NAMESPACE, 'svg'),
+    path: document.createElementNS(SVG_NAMESPACE, 'path'),
+  };
+
+  t.context.parent.appendChild(t.context.svg);
+  document.body.appendChild(t.context.parent);
+});
+
+test('cloneNode should create a new node with the same type', t => {
+  const { svg } = t.context;
+
+  t.is(svg.cloneNode().namespaceURI, svg.namespaceURI);
+});
+
+test('cloneNode should create a new node with the same tagName', t => {
+  const { svg } = t.context;
+
+  t.is(svg.cloneNode().tagName, svg.tagName);
+});
+
+test('cloneNode should create a new node with a different index', t => {
+  const { svg } = t.context;
+
+  t.not(svg.cloneNode()[TransferrableKeys.index], svg[TransferrableKeys.index]);
+});
+
+test('cloneNode should create a new node with the same attribute', t => {
+  const { svg } = t.context;
+  svg.setAttribute('fancy', 'yes');
+
+  t.is(svg.cloneNode().getAttribute('fancy'), 'yes');
+});
+
+test('cloneNode should create a new node with the same attributes', t => {
+  const { svg } = t.context;
+  svg.setAttribute('fancy', 'yes');
+  svg.setAttribute('virtual', 'no');
+
+  t.is(svg.cloneNode().getAttribute('fancy'), 'yes');
+  t.is(svg.cloneNode().getAttribute('virtual'), 'no');
+});
+
+test('cloneNode should create a new node with the same attributes, but not preserve attributes across the instances', t => {
+  const { svg } = t.context;
+  svg.setAttribute('fancy', 'yes');
+  const clone = svg.cloneNode();
+  svg.setAttribute('fancy', 'no');
+
+  t.is(clone.getAttribute('fancy'), 'yes');
+  t.is(svg.getAttribute('fancy'), 'no');
+});
+
+test('cloneNode should create a new node without the same properties', t => {
+  const { svg } = t.context;
+  svg.value = 'property value';
+
+  t.not(svg.cloneNode().value, 'property value');
+});
+
+test('cloneNode should create a new node without the same children when the deep flag is not set', t => {
+  const { svg } = t.context;
+  const clone = svg.cloneNode();
+
+  t.is(clone.childNodes.length, 0);
+});
+
+test('cloneNode should create a new node with the same children when the deep flag is set', t => {
+  const { svg, path } = t.context;
+  svg.appendChild(path);
+  const clone = svg.cloneNode(true);
+
+  t.is(svg.childNodes.length, clone.childNodes.length);
+  t.is(svg.childNodes[0].tagName, clone.childNodes[0].tagName);
+});

--- a/src/test/svgelement/namespaceURI.test.ts
+++ b/src/test/svgelement/namespaceURI.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'ava';
+import { createTestingDocument } from '../DocumentCreation';
+import { SVG_NAMESPACE } from '../../transfer/TransferrableNodes';
+
+test('svg should have the SVG namespaceURI', t => {
+  const document = createTestingDocument();
+  const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
+
+  t.is(svg.namespaceURI, SVG_NAMESPACE);
+});

--- a/src/worker-thread/WorkerDOMGlobalScope.ts
+++ b/src/worker-thread/WorkerDOMGlobalScope.ts
@@ -47,6 +47,7 @@ import { Document } from './dom/Document';
 import { EventHandler } from './Event';
 import { HydrateableNode } from '../transfer/TransferrableNodes';
 import { MutationObserver } from './MutationObserver';
+import { SVGElement } from './dom/SVGElement';
 
 export interface GlobalScope {
   initialize: (document: Document, strings: Array<string>, hydrateableNode: HydrateableNode, keys: Array<string>) => void;
@@ -57,6 +58,7 @@ export interface GlobalScope {
   innerWidth: number;
   innerHeight: number;
   MutationObserver: typeof MutationObserver;
+  SVGElement: typeof SVGElement;
   HTMLAnchorElement: typeof HTMLAnchorElement;
   HTMLButtonElement: typeof HTMLButtonElement;
   HTMLCanvasElement: typeof HTMLCanvasElement;

--- a/src/worker-thread/dom/Element.ts
+++ b/src/worker-thread/dom/Element.ts
@@ -36,10 +36,8 @@ import { parse } from '../../third_party/html-parser/html-parser';
 import { propagate } from './Node';
 
 export const NS_NAME_TO_CLASS: { [key: string]: typeof Element } = {};
-export function registerSubclass(localName: string, subclass: typeof Element, namespace: string = HTML_NAMESPACE): void {
-  const key = `${namespace}:${localName}`;
-  NS_NAME_TO_CLASS[key] = subclass;
-}
+export const registerSubclass = (localName: string, subclass: typeof Element, namespace: string = HTML_NAMESPACE): any =>
+  (NS_NAME_TO_CLASS[`${namespace}:${localName}`] = subclass);
 
 interface PropertyBackedAttributes {
   [key: string]: [(el: Element) => string | null, (el: Element, value: string) => string | boolean];
@@ -483,7 +481,7 @@ export class Element extends ParentNode {
    * @return Element containing all current attributes and potentially childNode clones of the Element requested to be cloned.
    */
   public cloneNode(deep: boolean = false): Element {
-    const clone: Element = this.ownerDocument.createElement(this.nodeName);
+    const clone: Element = this.ownerDocument.createElementNS(this.namespaceURI, this.nodeName);
     this.attributes.forEach(attr => clone.setAttribute(attr.name, attr.value));
     if (deep) {
       this.childNodes.forEach((child: Node) => clone.appendChild(child.cloneNode(deep)));

--- a/src/worker-thread/index.amp.ts
+++ b/src/worker-thread/index.amp.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { SVGElement } from './dom/SVGElement';
 import { HTMLAnchorElement } from './dom/HTMLAnchorElement';
 import { HTMLButtonElement } from './dom/HTMLButtonElement';
 import { HTMLCanvasElement } from './dom/HTMLCanvasElement';
@@ -138,6 +139,7 @@ const globalScope: GlobalScope = {
   innerHeight: 0,
   initialize,
   MutationObserver,
+  SVGElement,
   HTMLAnchorElement,
   HTMLButtonElement,
   HTMLCanvasElement,

--- a/src/worker-thread/index.ts
+++ b/src/worker-thread/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { SVGElement } from './dom/SVGElement';
 import { HTMLAnchorElement } from './dom/HTMLAnchorElement';
 import { HTMLButtonElement } from './dom/HTMLButtonElement';
 import { HTMLCanvasElement } from './dom/HTMLCanvasElement';
@@ -57,6 +58,7 @@ const globalScope: GlobalScope = {
   innerHeight: 0,
   initialize,
   MutationObserver,
+  SVGElement,
   HTMLAnchorElement,
   HTMLButtonElement,
   HTMLCanvasElement,


### PR DESCRIPTION
This fixes cloneNode to support Elements with custom namespaces.