### PR TITLE
CSSStyleDeclaration Test for numerical keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/worker-dom",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "A facsimile of a modern DOM implementation intended to run in a Web Worker.",
   "main": "dist/main",
   "syntax": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/worker-dom",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A facsimile of a modern DOM implementation intended to run in a Web Worker.",
   "main": "dist/main",
   "syntax": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/worker-dom",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "A facsimile of a modern DOM implementation intended to run in a Web Worker.",
   "main": "dist/main",
   "syntax": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/worker-dom",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A facsimile of a modern DOM implementation intended to run in a Web Worker.",
   "main": "dist/main",
   "syntax": {

--- a/src/test/cssstyledeclaration/appendKeys.test.ts
+++ b/src/test/cssstyledeclaration/appendKeys.test.ts
@@ -18,6 +18,7 @@ import anyTest, { TestInterface } from 'ava';
 import { CSSStyleDeclaration, appendKeys } from '../../worker-thread/css/CSSStyleDeclaration';
 import { Element } from '../../worker-thread/dom/Element';
 import { createTestingDocument } from '../DocumentCreation';
+import { TransferrableKeys } from '../../transfer/TransferrableKeys';
 
 const test = anyTest as TestInterface<{
   node: Element;
@@ -71,4 +72,14 @@ test('reappending a key does not cause an error', t => {
   appendKeys(['width']);
 
   t.is(declaration.width, '');
+});
+
+test('appending as many keys as there are TransferrableKeys functions', t => {
+  const declaration = new CSSStyleDeclaration(t.context.node);
+  appendKeys(['width']);
+  appendKeys(Array.from(Array(TransferrableKeys.END), (d, i) => i + 'key'));
+
+  t.is(declaration.width, '');
+  declaration.width = '40px';
+  t.is(declaration.width, '40px');
 });

--- a/src/transfer/TransferrableKeys.ts
+++ b/src/transfer/TransferrableKeys.ts
@@ -83,4 +83,6 @@ export const enum TransferrableKeys {
   offsetX = 65,
   offsetY = 66,
   mutated = 67,
+  // This must always be the last numerically ordered Key, for testing purposes.
+  END = 68,
 }


### PR DESCRIPTION
This test ensures we don't break `CSSStyleDeclaration` again with numerical keys from `TransferrableKeys`.