### PR TITLE
Add "amp/worker/worker.js" output

### DIFF
--- a/config/rollup.worker-thread.js
+++ b/config/rollup.worker-thread.js
@@ -94,6 +94,28 @@ const ESModules = [
       }),
     ],
   },
+  {
+    input: 'output/worker-thread/index.amp.js',
+    output: {
+      file: 'dist/amp/worker/worker.js',
+      format: 'iife',
+      name: 'WorkerThread',
+      sourcemap: true,
+    },
+    plugins: [
+      copy({
+        targets: ['config/dist-packaging/amp/worker/package.json'],
+        outputFolder: 'dist/amp/worker',
+      }),
+      replace({
+        DEBUG_ENABLED: false,
+      }),
+      babelPlugin({
+        transpileToES5: true,
+        allowConsole: false,
+      }),
+    ],
+  },
 ];
 
 const IIFEModules = [

--- a/config/rollup.worker-thread.js
+++ b/config/rollup.worker-thread.js
@@ -20,6 +20,14 @@ import replace from 'rollup-plugin-replace';
 import copy from 'rollup-plugin-copy';
 import { babelPlugin } from './rollup.plugins.js';
 
+// Compile plugins should always be added at the end of the plugin list.
+const compilePlugins = [
+  compiler({
+    env: 'CUSTOM',
+  }),
+  terser(),
+];
+
 // Workers do not natively support ES Modules containing `import` or `export` statments.
 // So, here we continue to use the '.mjs' extension to indicate newer ECMASCRIPT support
 // but ensure the code can be run within a worker by putting it inside a named iife.
@@ -44,10 +52,7 @@ const ESModules = [
         transpileToES5: false,
         allowConsole: false,
       }),
-      compiler({
-        env: 'CUSTOM',
-      }),
-      terser(),
+      ...compilePlugins,
     ],
   },
   {
@@ -114,6 +119,7 @@ const ESModules = [
         transpileToES5: true,
         allowConsole: false,
       }),
+      ...compilePlugins,
     ],
   },
 ];
@@ -135,10 +141,7 @@ const IIFEModules = [
         transpileToES5: true,
         allowConsole: false,
       }),
-      compiler({
-        env: 'CUSTOM',
-      }),
-      terser(),
+      ...compilePlugins,
     ],
   },
   {


### PR DESCRIPTION
With debugging/console disabled, transpiled to ES5, and compiled/tersed.