### PR TITLE
Allowlist indexedDB, Strings->StringContext, other cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     {
       "path": "./dist/worker/worker.js",
       "compression": "brotli",
-      "maxSize": "12.1 kB"
+      "maxSize": "12.2 kB"
     },
     {
       "path": "./dist/main.mjs",

--- a/src/main-thread/commands/interface.ts
+++ b/src/main-thread/commands/interface.ts
@@ -15,7 +15,7 @@
  */
 
 import { WorkerDOMConfiguration } from '../configuration';
-import { Strings } from '../strings';
+import { StringContext } from '../strings';
 import { NodeContext } from '../nodes';
 import { WorkerContext } from '../worker';
 import { ObjectContext } from '../object-context';
@@ -27,7 +27,7 @@ export interface CommandExecutor {
 
 export interface CommandExecutorInterface {
   (
-    strings: Strings,
+    stringContext: StringContext,
     nodeContext: NodeContext,
     workerContext: WorkerContext,
     objectContext: ObjectContext,

--- a/src/main-thread/commands/long-task.ts
+++ b/src/main-thread/commands/long-task.ts
@@ -16,7 +16,7 @@
 
 import { CommandExecutor, CommandExecutorInterface } from './interface';
 import { TransferrableMutationType, ReadableMutationType, LongTaskMutationIndex } from '../../transfer/TransferrableMutation';
-import { Strings } from '../strings';
+import { StringContext } from '../strings';
 import { NodeContext } from '../nodes';
 import { WorkerContext } from '../worker';
 import { WorkerDOMConfiguration } from '../configuration';
@@ -24,7 +24,7 @@ import { ObjectContext } from '../object-context';
 
 export interface LongTaskCommandExecutorInterface extends CommandExecutorInterface {
   (
-    strings: Strings,
+    stringContext: StringContext,
     nodeContext: NodeContext,
     workerContext: WorkerContext,
     objectContext: ObjectContext,
@@ -36,7 +36,7 @@ export interface LongTaskCommandExecutor extends CommandExecutor {
 }
 
 export const LongTaskExecutor: LongTaskCommandExecutorInterface = (
-  strings: Strings,
+  strings: StringContext,
   nodeContext: NodeContext,
   workerContext: WorkerContext,
   objectContext: ObjectContext,

--- a/src/main-thread/commands/long-task.ts
+++ b/src/main-thread/commands/long-task.ts
@@ -36,7 +36,7 @@ export interface LongTaskCommandExecutor extends CommandExecutor {
 }
 
 export const LongTaskExecutor: LongTaskCommandExecutorInterface = (
-  strings: StringContext,
+  stringContext: StringContext,
   nodeContext: NodeContext,
   workerContext: WorkerContext,
   objectContext: ObjectContext,

--- a/src/main-thread/deserializeTransferrableObject.ts
+++ b/src/main-thread/deserializeTransferrableObject.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Strings } from './strings';
+import { StringContext } from './strings';
 import { TransferrableObjectType } from '../transfer/TransferrableMutation';
 import { NodeContext } from './nodes';
 import { ObjectContext } from './object-context';
@@ -32,7 +32,7 @@ const u16 = new Uint16Array(f32.buffer);
  * @param buffer Contains mutation with arguments to deserialize.
  * @param offset Start position of arguments in mutations buffer.
  * @param count Number of arguments to deserialize.
- * @param strings Strings context.
+ * @param stringContext Strings context.
  * @param nodeContext Nodes context.
  * @param objectContext Objects context
  */
@@ -40,7 +40,7 @@ export function deserializeTransferrableObject(
   buffer: Uint16Array,
   offset: number,
   count: number,
-  strings: Strings,
+  stringContext: StringContext,
   nodeContext: NodeContext,
   objectContext?: ObjectContext,
 ): DeserializedArgs {
@@ -58,12 +58,12 @@ export function deserializeTransferrableObject(
         break;
 
       case TransferrableObjectType.String:
-        args.push(strings.get(buffer[offset++]));
+        args.push(stringContext.get(buffer[offset++]));
         break;
 
       case TransferrableObjectType.Array:
         const size = buffer[offset++];
-        const des = deserializeTransferrableObject(buffer, offset, size, strings, nodeContext, objectContext);
+        const des = deserializeTransferrableObject(buffer, offset, size, stringContext, nodeContext, objectContext);
         args.push(des.args);
         offset = des.offset;
         break;

--- a/src/main-thread/install.ts
+++ b/src/main-thread/install.ts
@@ -17,7 +17,7 @@
 import { MutationFromWorker, MessageType, MessageFromWorker } from '../transfer/Messages';
 import { MutatorProcessor } from './mutator';
 import { NodeContext } from './nodes';
-import { Strings } from './strings';
+import { StringContext } from './strings';
 import { TransferrableKeys } from '../transfer/TransferrableKeys';
 import { InboundWorkerDOMConfiguration, normalizeConfiguration } from './configuration';
 import { WorkerContext } from './worker';
@@ -52,14 +52,14 @@ export function install(
   baseElement: HTMLElement,
   config: InboundWorkerDOMConfiguration,
 ): Promise<Worker | null> {
-  const strings = new Strings();
+  const stringContext = new StringContext();
   const objectContext = new ObjectContext();
-  const nodeContext = new NodeContext(strings, baseElement);
+  const nodeContext = new NodeContext(stringContext, baseElement);
   const normalizedConfig = normalizeConfiguration(config);
   return fetchPromise.then(([domScriptContent, authorScriptContent]) => {
     if (domScriptContent && authorScriptContent && config.authorURL) {
       const workerContext = new WorkerContext(baseElement, nodeContext, domScriptContent, authorScriptContent, normalizedConfig);
-      const mutatorContext = new MutatorProcessor(strings, nodeContext, workerContext, normalizedConfig, objectContext);
+      const mutatorContext = new MutatorProcessor(stringContext, nodeContext, workerContext, normalizedConfig, objectContext);
       workerContext.worker.onmessage = (message: MessageFromWorker) => {
         const { data } = message;
 

--- a/src/main-thread/nodes.ts
+++ b/src/main-thread/nodes.ts
@@ -19,7 +19,7 @@ import { StringContext } from './strings';
 
 export class NodeContext {
   public baseElement: HTMLElement;
-  private strings: StringContext;
+  private stringContext: StringContext;
   private count: number;
   private nodes: Map<number, Node>;
 
@@ -29,9 +29,9 @@ export class NodeContext {
    * Worker.
    * @param baseElement Element that will be controlled by a Worker
    */
-  constructor(strings: StringContext, baseElement: Element) {
+  constructor(stringContext: StringContext, baseElement: Element) {
     this.count = 2;
-    this.strings = strings;
+    this.stringContext = stringContext;
 
     // The nodes map is populated with two default values pointing to baseElement.
     // These are [document, document.body] from the worker.
@@ -52,16 +52,16 @@ export class NodeContext {
     for (let iterator = 0; iterator < nodeBufferLength; iterator += TransferrableNodeIndex.End) {
       let node: Node;
       if (nodeBuffer[iterator + TransferrableNodeIndex.NodeType] === NodeType.TEXT_NODE) {
-        node = document.createTextNode(this.strings.get(nodeBuffer[iterator + TransferrableNodeIndex.TextContent]));
+        node = document.createTextNode(this.stringContext.get(nodeBuffer[iterator + TransferrableNodeIndex.TextContent]));
       } else if (nodeBuffer[iterator + TransferrableNodeIndex.NodeType] === NodeType.COMMENT_NODE) {
-        node = document.createComment(this.strings.get(nodeBuffer[iterator + TransferrableNodeIndex.TextContent]));
+        node = document.createComment(this.stringContext.get(nodeBuffer[iterator + TransferrableNodeIndex.TextContent]));
       } else if (nodeBuffer[iterator + TransferrableNodeIndex.NodeType] === NodeType.DOCUMENT_FRAGMENT_NODE) {
         node = document.createDocumentFragment();
       } else {
-        const nodeName = this.strings.get(nodeBuffer[iterator + TransferrableNodeIndex.NodeName]);
+        const nodeName = this.stringContext.get(nodeBuffer[iterator + TransferrableNodeIndex.NodeName]);
         node =
           nodeBuffer[iterator + TransferrableNodeIndex.Namespace] !== 0
-            ? document.createElementNS(this.strings.get(nodeBuffer[iterator + TransferrableNodeIndex.Namespace]), nodeName)
+            ? document.createElementNS(this.stringContext.get(nodeBuffer[iterator + TransferrableNodeIndex.Namespace]), nodeName)
             : document.createElement(nodeName);
 
         // TODO(KB): Restore Properties

--- a/src/main-thread/nodes.ts
+++ b/src/main-thread/nodes.ts
@@ -15,11 +15,11 @@
  */
 
 import { NodeType, TransferrableNodeIndex } from '../transfer/TransferrableNodes';
-import { Strings } from './strings';
+import { StringContext } from './strings';
 
 export class NodeContext {
   public baseElement: HTMLElement;
-  private strings: Strings;
+  private strings: StringContext;
   private count: number;
   private nodes: Map<number, Node>;
 
@@ -29,7 +29,7 @@ export class NodeContext {
    * Worker.
    * @param baseElement Element that will be controlled by a Worker
    */
-  constructor(strings: Strings, baseElement: Element) {
+  constructor(strings: StringContext, baseElement: Element) {
     this.count = 2;
     this.strings = strings;
 

--- a/src/main-thread/strings.ts
+++ b/src/main-thread/strings.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-export class Strings {
+/**
+ * Stores indexed strings that are used in postMessage() calls from the worker.
+ */
+export class StringContext {
   private strings: Array<string>;
 
   constructor() {
@@ -44,6 +47,6 @@ export class Strings {
    * @param values
    */
   storeValues(values: Array<string>): void {
-    values.forEach(this.store.bind(this));
+    values.forEach(v => this.store(v));
   }
 }

--- a/src/test/DocumentCreation.ts
+++ b/src/test/DocumentCreation.ts
@@ -97,7 +97,6 @@ const GlobalScope: GlobalScope = {
   localStorage: {},
   location: {},
   url: '/',
-  indexedDB: {} as IDBFactory,
   innerWidth: 0,
   innerHeight: 0,
   initialize: (document: Document, strings: Array<string>, hydrateableNode: HydrateableNode, keys: Array<string>) => void 0,

--- a/src/test/DocumentCreation.ts
+++ b/src/test/DocumentCreation.ts
@@ -97,6 +97,7 @@ const GlobalScope: GlobalScope = {
   localStorage: {},
   location: {},
   url: '/',
+  indexedDB: {} as IDBFactory,
   innerWidth: 0,
   innerHeight: 0,
   initialize: (document: Document, strings: Array<string>, hydrateableNode: HydrateableNode, keys: Array<string>) => void 0,

--- a/src/test/main-thread/deserializeTransferrableObject.test.ts
+++ b/src/test/main-thread/deserializeTransferrableObject.test.ts
@@ -17,13 +17,13 @@
 import anyTest, { TestInterface } from 'ava';
 import { TransferrableObjectType } from '../../transfer/TransferrableMutation';
 import { deserializeTransferrableObject } from '../../main-thread/deserializeTransferrableObject';
-import { Strings } from '../../main-thread/strings';
+import { StringContext } from '../../main-thread/strings';
 import { NodeContext } from '../../main-thread/nodes';
 import { Env } from './helpers/env';
 import { ObjectContext } from '../../main-thread/object-context';
 
 const test = anyTest as TestInterface<{
-  strings: Strings;
+  stringContext: StringContext;
   nodeContext: NodeContext;
   objectContext: ObjectContext;
 }>;
@@ -33,19 +33,19 @@ test.beforeEach(t => {
   const { document } = env;
   const baseElement = document.createElement('div');
 
-  const strings = new Strings();
+  const stringContext = new StringContext();
   const objectContext = new ObjectContext();
-  const nodeContext = new NodeContext(strings, baseElement);
+  const nodeContext = new NodeContext(stringContext, baseElement);
 
   t.context = {
-    strings,
+    stringContext: stringContext,
     nodeContext,
     objectContext,
   };
 });
 
 test('Deserializes int arguments', t => {
-  const { strings, nodeContext } = t.context;
+  const { stringContext: strings, nodeContext } = t.context;
 
   const serializedArgs = [TransferrableObjectType.SmallInt, 1];
   const buffer = new Uint16Array(serializedArgs);
@@ -55,7 +55,7 @@ test('Deserializes int arguments', t => {
 });
 
 test('Deserializes float arguments', t => {
-  const { strings, nodeContext } = t.context;
+  const { stringContext: strings, nodeContext } = t.context;
 
   const f32 = new Float32Array(1);
   const u16 = new Uint16Array(f32.buffer);
@@ -69,7 +69,7 @@ test('Deserializes float arguments', t => {
 });
 
 test('Deserializes string arguments', t => {
-  const { strings, nodeContext } = t.context;
+  const { stringContext: strings, nodeContext } = t.context;
 
   const serializedArgs = [TransferrableObjectType.String, storeString(strings, 'textArg')];
   const buffer = new Uint16Array(serializedArgs);
@@ -79,7 +79,7 @@ test('Deserializes string arguments', t => {
 });
 
 test('Deserializes array argument', t => {
-  const { strings, nodeContext } = t.context;
+  const { stringContext: strings, nodeContext } = t.context;
 
   const serializedArgs = [
     TransferrableObjectType.Array,
@@ -99,7 +99,7 @@ test('Deserializes array argument', t => {
 });
 
 test('Deserializes object argument', t => {
-  const { strings, nodeContext, objectContext } = t.context;
+  const { stringContext: strings, nodeContext, objectContext } = t.context;
 
   const id = 5; // example object id
   const obj = {} as CanvasGradient;
@@ -113,7 +113,7 @@ test('Deserializes object argument', t => {
 });
 
 test('Deserializes varying types', t => {
-  const { strings, nodeContext, objectContext } = t.context;
+  const { stringContext: strings, nodeContext, objectContext } = t.context;
 
   // argument 1: SmallInt
   const smallInt = 1;
@@ -143,7 +143,7 @@ test('Deserializes varying types', t => {
 });
 
 test('Deserializes from different offset', t => {
-  const { strings, nodeContext } = t.context;
+  const { stringContext: strings, nodeContext } = t.context;
 
   const serializedArgs = [TransferrableObjectType.SmallInt, 1];
   const buffer = new Uint16Array([1, 2, 3].concat(serializedArgs));
@@ -153,7 +153,7 @@ test('Deserializes from different offset', t => {
 });
 
 test('Returns the correct end offset', t => {
-  const { strings, nodeContext } = t.context;
+  const { stringContext: strings, nodeContext } = t.context;
 
   const serializedArgs = [
     TransferrableObjectType.SmallInt,
@@ -173,8 +173,8 @@ test('Returns the correct end offset', t => {
 
 // main-thread's strings API does not return an ID when storing a string
 // so for convenience:
-function storeString(strings: Strings, text: string, currentIndex = -1) {
-  strings.store(text);
+function storeString(stringContext: StringContext, text: string, currentIndex = -1) {
+  stringContext.store(text);
   return ++currentIndex;
 }
 

--- a/src/test/main-thread/deserializeTransferrableObject.test.ts
+++ b/src/test/main-thread/deserializeTransferrableObject.test.ts
@@ -38,24 +38,24 @@ test.beforeEach(t => {
   const nodeContext = new NodeContext(stringContext, baseElement);
 
   t.context = {
-    stringContext: stringContext,
+    stringContext,
     nodeContext,
     objectContext,
   };
 });
 
 test('Deserializes int arguments', t => {
-  const { stringContext: strings, nodeContext } = t.context;
+  const { stringContext, nodeContext } = t.context;
 
   const serializedArgs = [TransferrableObjectType.SmallInt, 1];
   const buffer = new Uint16Array(serializedArgs);
-  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 0, 1, strings, nodeContext);
+  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 0, 1, stringContext, nodeContext);
 
   t.deepEqual(deserializedArgs, [1]);
 });
 
 test('Deserializes float arguments', t => {
-  const { stringContext: strings, nodeContext } = t.context;
+  const { stringContext, nodeContext } = t.context;
 
   const f32 = new Float32Array(1);
   const u16 = new Uint16Array(f32.buffer);
@@ -63,23 +63,23 @@ test('Deserializes float arguments', t => {
 
   const serializedArgs = [TransferrableObjectType.Float, u16[0], u16[1]];
   const buffer = new Uint16Array(serializedArgs);
-  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 0, 1, strings, nodeContext);
+  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 0, 1, stringContext, nodeContext);
 
   t.true(approx(1.23, deserializedArgs[0] as number));
 });
 
 test('Deserializes string arguments', t => {
-  const { stringContext: strings, nodeContext } = t.context;
+  const { stringContext, nodeContext } = t.context;
 
-  const serializedArgs = [TransferrableObjectType.String, storeString(strings, 'textArg')];
+  const serializedArgs = [TransferrableObjectType.String, storeString(stringContext, 'textArg')];
   const buffer = new Uint16Array(serializedArgs);
-  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 0, 1, strings, nodeContext);
+  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 0, 1, stringContext, nodeContext);
 
   t.deepEqual(deserializedArgs, ['textArg']);
 });
 
 test('Deserializes array argument', t => {
-  const { stringContext: strings, nodeContext } = t.context;
+  const { stringContext, nodeContext } = t.context;
 
   const serializedArgs = [
     TransferrableObjectType.Array,
@@ -93,13 +93,13 @@ test('Deserializes array argument', t => {
   ];
 
   const buffer = new Uint16Array(serializedArgs);
-  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 0, 1, strings, nodeContext);
+  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 0, 1, stringContext, nodeContext);
 
   t.deepEqual(deserializedArgs, [[1, 2, 3]]);
 });
 
 test('Deserializes object argument', t => {
-  const { stringContext: strings, nodeContext, objectContext } = t.context;
+  const { stringContext, nodeContext, objectContext } = t.context;
 
   const id = 5; // example object id
   const obj = {} as CanvasGradient;
@@ -107,20 +107,20 @@ test('Deserializes object argument', t => {
 
   const serializedArgs = [TransferrableObjectType.TransferObject, id];
   const buffer = new Uint16Array(serializedArgs);
-  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 0, 1, strings, nodeContext, objectContext);
+  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 0, 1, stringContext, nodeContext, objectContext);
 
   t.deepEqual(deserializedArgs, [obj]);
 });
 
 test('Deserializes varying types', t => {
-  const { stringContext: strings, nodeContext, objectContext } = t.context;
+  const { stringContext, nodeContext, objectContext } = t.context;
 
   // argument 1: SmallInt
   const smallInt = 1;
 
   // argument 2: String
   const stringArg = 'textArg';
-  const stringId = storeString(strings, stringArg);
+  const stringId = storeString(stringContext, stringArg);
 
   // argument 3: Object
   const objectId = 7;
@@ -137,23 +137,23 @@ test('Deserializes varying types', t => {
   ];
   const buffer = new Uint16Array(serializedArgs);
 
-  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 0, 3, strings, nodeContext, objectContext);
+  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 0, 3, stringContext, nodeContext, objectContext);
 
   t.deepEqual(deserializedArgs, [smallInt, stringArg, object]);
 });
 
 test('Deserializes from different offset', t => {
-  const { stringContext: strings, nodeContext } = t.context;
+  const { stringContext, nodeContext } = t.context;
 
   const serializedArgs = [TransferrableObjectType.SmallInt, 1];
   const buffer = new Uint16Array([1, 2, 3].concat(serializedArgs));
-  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 3, 1, strings, nodeContext);
+  const { args: deserializedArgs } = deserializeTransferrableObject(buffer, 3, 1, stringContext, nodeContext);
 
   t.deepEqual(deserializedArgs, [1]);
 });
 
 test('Returns the correct end offset', t => {
-  const { stringContext: strings, nodeContext } = t.context;
+  const { stringContext, nodeContext } = t.context;
 
   const serializedArgs = [
     TransferrableObjectType.SmallInt,
@@ -166,7 +166,7 @@ test('Returns the correct end offset', t => {
   ];
 
   const buffer = new Uint16Array([1, 2, 3].concat(serializedArgs));
-  const { offset: endOffset } = deserializeTransferrableObject(buffer, 3, 2, strings, nodeContext);
+  const { offset: endOffset } = deserializeTransferrableObject(buffer, 3, 2, stringContext, nodeContext);
 
   t.is(buffer[endOffset], 32);
 });

--- a/src/test/main-thread/long-task.test.ts
+++ b/src/test/main-thread/long-task.test.ts
@@ -18,7 +18,7 @@ import anyTest, { TestInterface } from 'ava';
 import { Env } from './helpers/env';
 import { LongTaskCommandExecutor, LongTaskExecutor } from '../../main-thread/commands/long-task';
 import { TransferrableMutationType } from '../../transfer/TransferrableMutation';
-import { Strings } from '../../main-thread/strings';
+import { StringContext } from '../../main-thread/strings';
 import { NodeContext } from '../../main-thread/nodes';
 import { WorkerContext } from '../../main-thread/worker';
 import { normalizeConfiguration } from '../../main-thread/configuration';
@@ -28,7 +28,7 @@ const test = anyTest as TestInterface<{
   env: Env;
   executor: LongTaskCommandExecutor;
   longTasks: Array<Promise<any>>;
-  strings: Strings;
+  stringContext: StringContext;
   nodeContext: NodeContext;
   workerContext: WorkerContext;
   objectContext: ObjectContext;
@@ -40,15 +40,15 @@ test.beforeEach(t => {
   const { document } = env;
   const longTasks: Array<Promise<any>> = [];
   const baseElement = document.createElement('div');
-  const strings = new Strings();
-  const nodeContext = new NodeContext(strings, baseElement);
+  const stringContext = new StringContext();
+  const nodeContext = new NodeContext(stringContext, baseElement);
   const objectContext = new ObjectContext();
   const workerContext = ({
     getWorker() {},
     messageToWorker() {},
   } as unknown) as WorkerContext;
   const executor = LongTaskExecutor(
-    strings,
+    stringContext,
     nodeContext,
     workerContext,
     objectContext,
@@ -69,7 +69,7 @@ test.beforeEach(t => {
     executor,
     longTasks,
     baseElement,
-    strings,
+    stringContext: stringContext,
     nodeContext,
     objectContext,
     workerContext,
@@ -82,7 +82,7 @@ test.afterEach(t => {
 });
 
 test.serial('should tolerate no callback', t => {
-  const { longTasks, baseElement, strings, nodeContext, workerContext, objectContext } = t.context;
+  const { longTasks, baseElement, stringContext: strings, nodeContext, workerContext, objectContext } = t.context;
   const executor = LongTaskExecutor(
     strings,
     nodeContext,

--- a/src/test/main-thread/long-task.test.ts
+++ b/src/test/main-thread/long-task.test.ts
@@ -69,7 +69,7 @@ test.beforeEach(t => {
     executor,
     longTasks,
     baseElement,
-    stringContext: stringContext,
+    stringContext,
     nodeContext,
     objectContext,
     workerContext,
@@ -82,9 +82,9 @@ test.afterEach(t => {
 });
 
 test.serial('should tolerate no callback', t => {
-  const { longTasks, baseElement, stringContext: strings, nodeContext, workerContext, objectContext } = t.context;
+  const { longTasks, baseElement, stringContext, nodeContext, workerContext, objectContext } = t.context;
   const executor = LongTaskExecutor(
-    strings,
+    stringContext,
     nodeContext,
     workerContext,
     objectContext,

--- a/src/test/main-thread/mutator.test.ts
+++ b/src/test/main-thread/mutator.test.ts
@@ -18,7 +18,7 @@ import anyTest, { TestInterface } from 'ava';
 import { Env } from './helpers/env';
 import { MutatorProcessor } from '../../main-thread/mutator';
 import { NodeContext } from '../../main-thread/nodes';
-import { Strings } from '../../main-thread/strings';
+import { StringContext } from '../../main-thread/strings';
 import { WorkerContext } from '../../main-thread/worker';
 import { TransferrableMutationType } from '../../transfer/TransferrableMutation';
 import { Phase } from '../../transfer/Phase';
@@ -28,7 +28,7 @@ import { ObjectContext } from '../../main-thread/object-context';
 const test = anyTest as TestInterface<{
   env: Env;
   baseElement: Element;
-  strings: Strings;
+  stringContext: StringContext;
   nodeContext: NodeContext;
   workerContext: WorkerContext;
   objectContext: ObjectContext;
@@ -41,9 +41,9 @@ test.beforeEach(t => {
   const baseElement = document.createElement('div');
   document.body.appendChild(baseElement);
 
-  const strings = new Strings();
+  const stringContext = new StringContext();
   const objectContext = new ObjectContext();
-  const nodeContext = new NodeContext(strings, baseElement);
+  const nodeContext = new NodeContext(stringContext, baseElement);
 
   const workerContext = ({
     getWorker() {},
@@ -53,7 +53,7 @@ test.beforeEach(t => {
   t.context = {
     env,
     baseElement,
-    strings,
+    stringContext: stringContext,
     nodeContext,
     workerContext,
     objectContext,
@@ -66,7 +66,7 @@ test.afterEach(t => {
 });
 
 test.serial('batch mutations', t => {
-  const { env, baseElement, strings, nodeContext, workerContext, objectContext } = t.context;
+  const { env, baseElement, stringContext: strings, nodeContext, workerContext, objectContext } = t.context;
   const { rafTasks } = env;
   const mutator = new MutatorProcessor(
     strings,
@@ -131,7 +131,7 @@ test.serial('batch mutations', t => {
 });
 
 test.serial('batch mutations with custom pump', t => {
-  const { env, baseElement, strings, nodeContext, workerContext, objectContext } = t.context;
+  const { env, baseElement, stringContext: strings, nodeContext, workerContext, objectContext } = t.context;
   const { rafTasks } = env;
 
   const tasks: Array<{ phase: Phase; flush: Function }> = [];
@@ -204,7 +204,7 @@ test.serial('batch mutations with custom pump', t => {
 });
 
 test.serial('leverage allowlist to exclude mutation type', t => {
-  const { env, baseElement, strings, nodeContext, workerContext, objectContext } = t.context;
+  const { env, baseElement, stringContext: strings, nodeContext, workerContext, objectContext } = t.context;
   const { rafTasks } = env;
   const mutator = new MutatorProcessor(
     strings,
@@ -252,7 +252,7 @@ test.serial('leverage allowlist to exclude mutation type', t => {
 });
 
 test.serial('split strings from mutations', t => {
-  const { env, baseElement, strings, nodeContext, workerContext, objectContext } = t.context;
+  const { env, baseElement, stringContext: strings, nodeContext, workerContext, objectContext } = t.context;
   const { rafTasks } = env;
   const mutator = new MutatorProcessor(
     strings,

--- a/src/test/main-thread/mutator.test.ts
+++ b/src/test/main-thread/mutator.test.ts
@@ -53,7 +53,7 @@ test.beforeEach(t => {
   t.context = {
     env,
     baseElement,
-    stringContext: stringContext,
+    stringContext,
     nodeContext,
     workerContext,
     objectContext,
@@ -66,10 +66,10 @@ test.afterEach(t => {
 });
 
 test.serial('batch mutations', t => {
-  const { env, baseElement, stringContext: strings, nodeContext, workerContext, objectContext } = t.context;
+  const { env, baseElement, stringContext, nodeContext, workerContext, objectContext } = t.context;
   const { rafTasks } = env;
   const mutator = new MutatorProcessor(
-    strings,
+    stringContext,
     nodeContext,
     workerContext,
     normalizeConfiguration({
@@ -131,12 +131,12 @@ test.serial('batch mutations', t => {
 });
 
 test.serial('batch mutations with custom pump', t => {
-  const { env, baseElement, stringContext: strings, nodeContext, workerContext, objectContext } = t.context;
+  const { env, baseElement, stringContext, nodeContext, workerContext, objectContext } = t.context;
   const { rafTasks } = env;
 
   const tasks: Array<{ phase: Phase; flush: Function }> = [];
   const mutator = new MutatorProcessor(
-    strings,
+    stringContext,
     nodeContext,
     workerContext,
     normalizeConfiguration({
@@ -204,10 +204,10 @@ test.serial('batch mutations with custom pump', t => {
 });
 
 test.serial('leverage allowlist to exclude mutation type', t => {
-  const { env, baseElement, stringContext: strings, nodeContext, workerContext, objectContext } = t.context;
+  const { env, baseElement, stringContext, nodeContext, workerContext, objectContext } = t.context;
   const { rafTasks } = env;
   const mutator = new MutatorProcessor(
-    strings,
+    stringContext,
     nodeContext,
     workerContext,
     normalizeConfiguration({
@@ -252,10 +252,10 @@ test.serial('leverage allowlist to exclude mutation type', t => {
 });
 
 test.serial('split strings from mutations', t => {
-  const { env, baseElement, stringContext: strings, nodeContext, workerContext, objectContext } = t.context;
+  const { env, baseElement, stringContext, nodeContext, workerContext, objectContext } = t.context;
   const { rafTasks } = env;
   const mutator = new MutatorProcessor(
-    strings,
+    stringContext,
     nodeContext,
     workerContext,
     normalizeConfiguration({

--- a/src/test/main-thread/object-creation.test.ts
+++ b/src/test/main-thread/object-creation.test.ts
@@ -16,7 +16,7 @@
 
 import anyTest, { TestInterface } from 'ava';
 import * as sinon from 'sinon';
-import { Strings } from '../../main-thread/strings';
+import { StringContext } from '../../main-thread/strings';
 import { ObjectContext } from '../../main-thread/object-context';
 import { CommandExecutor } from '../../main-thread/commands/interface';
 import { Env } from './helpers/env';
@@ -28,7 +28,7 @@ import { TransferrableObjectType } from '../../transfer/TransferrableMutation';
 import { TransferrableMutationType } from '../../transfer/TransferrableMutation';
 
 const test = anyTest as TestInterface<{
-  strings: Strings;
+  stringContext: StringContext;
   objectContext: ObjectContext;
   objectCreationProcessor: CommandExecutor;
   sandbox: sinon.SinonSandbox;
@@ -37,21 +37,21 @@ const test = anyTest as TestInterface<{
 
 test.beforeEach(t => {
   const sandbox = sinon.createSandbox();
-  const strings = new Strings();
+  const stringContext = new StringContext();
   const objectContext = new ObjectContext();
 
   const env = new Env();
   const { document } = env;
   const baseElement = document.createElement('div');
 
-  const nodeContext = new NodeContext(strings, baseElement);
+  const nodeContext = new NodeContext(stringContext, baseElement);
   const workerContext = ({
     getWorker() {},
     messageToWorker() {},
   } as unknown) as WorkerContext;
 
   const objectCreationProcessor = ObjectCreationProcessor(
-    strings,
+    stringContext,
     nodeContext,
     workerContext,
     objectContext,
@@ -66,7 +66,7 @@ test.beforeEach(t => {
   sandbox.stub(nodeContext, 'getNode').returns(canvasElement);
 
   t.context = {
-    strings,
+    stringContext: stringContext,
     objectContext,
     objectCreationProcessor,
     sandbox,
@@ -75,7 +75,7 @@ test.beforeEach(t => {
 });
 
 test('Object creation with mutation at a zero offset', t => {
-  const { strings, objectContext, objectCreationProcessor, sandbox, canvasElement } = t.context;
+  const { stringContext: strings, objectContext, objectCreationProcessor, sandbox, canvasElement } = t.context;
 
   const targetObject = canvasElement.getContext('2d');
   const methodName = 'createLinearGradient';
@@ -123,7 +123,7 @@ test('Object creation with mutation at a zero offset', t => {
 });
 
 test('Object creation with mutation at non-zero offset', t => {
-  const { strings, objectContext, objectCreationProcessor, sandbox, canvasElement } = t.context;
+  const { stringContext: strings, objectContext, objectCreationProcessor, sandbox, canvasElement } = t.context;
 
   const targetObject = canvasElement.getContext('2d');
   const methodName = 'createLinearGradient';
@@ -170,7 +170,7 @@ test('Object creation with mutation at non-zero offset', t => {
 });
 
 test('Returns correct end offset', t => {
-  const { strings, objectCreationProcessor, canvasElement, sandbox } = t.context;
+  const { stringContext: strings, objectCreationProcessor, canvasElement, sandbox } = t.context;
 
   const targetObject = canvasElement.getContext('2d');
 
@@ -210,7 +210,7 @@ test('Returns correct end offset', t => {
   t.is(mutationsArray[endOffset], 32);
 });
 
-function storeString(strings: Strings, text: string, currentIndex = -1) {
-  strings.store(text);
+function storeString(stringContext: StringContext, text: string, currentIndex = -1) {
+  stringContext.store(text);
   return ++currentIndex;
 }

--- a/src/test/main-thread/object-creation.test.ts
+++ b/src/test/main-thread/object-creation.test.ts
@@ -66,7 +66,7 @@ test.beforeEach(t => {
   sandbox.stub(nodeContext, 'getNode').returns(canvasElement);
 
   t.context = {
-    stringContext: stringContext,
+    stringContext,
     objectContext,
     objectCreationProcessor,
     sandbox,
@@ -75,7 +75,7 @@ test.beforeEach(t => {
 });
 
 test('Object creation with mutation at a zero offset', t => {
-  const { stringContext: strings, objectContext, objectCreationProcessor, sandbox, canvasElement } = t.context;
+  const { stringContext, objectContext, objectCreationProcessor, sandbox, canvasElement } = t.context;
 
   const targetObject = canvasElement.getContext('2d');
   const methodName = 'createLinearGradient';
@@ -108,7 +108,7 @@ test('Object creation with mutation at a zero offset', t => {
   objectCreationProcessor.execute(
     new Uint16Array([
       TransferrableMutationType.OBJECT_CREATION,
-      storeString(strings, methodName),
+      storeString(stringContext, methodName),
       objectId,
       4, // arg count
       ...serializedTarget,
@@ -123,7 +123,7 @@ test('Object creation with mutation at a zero offset', t => {
 });
 
 test('Object creation with mutation at non-zero offset', t => {
-  const { stringContext: strings, objectContext, objectCreationProcessor, sandbox, canvasElement } = t.context;
+  const { stringContext, objectContext, objectCreationProcessor, sandbox, canvasElement } = t.context;
 
   const targetObject = canvasElement.getContext('2d');
   const methodName = 'createLinearGradient';
@@ -154,7 +154,7 @@ test('Object creation with mutation at non-zero offset', t => {
 
   const mutation = [
     TransferrableMutationType.OBJECT_CREATION,
-    storeString(strings, methodName),
+    storeString(stringContext, methodName),
     objectId,
     4, // arg count
     ...serializedTarget,
@@ -170,7 +170,7 @@ test('Object creation with mutation at non-zero offset', t => {
 });
 
 test('Returns correct end offset', t => {
-  const { stringContext: strings, objectCreationProcessor, canvasElement, sandbox } = t.context;
+  const { stringContext, objectCreationProcessor, canvasElement, sandbox } = t.context;
 
   const targetObject = canvasElement.getContext('2d');
 
@@ -193,7 +193,7 @@ test('Returns correct end offset', t => {
 
   const mutation = [
     TransferrableMutationType.OBJECT_CREATION,
-    storeString(strings, methodName),
+    storeString(stringContext, methodName),
     1, // object ID (not important for this test)
     4, // arg count
     TransferrableObjectType.CanvasRenderingContext2D,

--- a/src/test/main-thread/object-mutation.test.ts
+++ b/src/test/main-thread/object-mutation.test.ts
@@ -67,7 +67,7 @@ test.beforeEach(t => {
 
   t.context = {
     sandbox,
-    stringContext: stringContext,
+    stringContext,
     objectContext,
     objectMutationProcessor,
     canvasElement,
@@ -80,7 +80,7 @@ test.afterEach(t => {
 });
 
 test('Method call with no arguments', t => {
-  const { sandbox, stringContext: strings, objectMutationProcessor, canvasElement } = t.context;
+  const { sandbox, stringContext, objectMutationProcessor, canvasElement } = t.context;
 
   const methodName = 'stroke';
   const targetObject = canvasElement.getContext('2d');
@@ -95,7 +95,7 @@ test('Method call with no arguments', t => {
     canvasElement,
     [TransferrableObjectType.CanvasRenderingContext2D, canvasElement._index_],
     methodName,
-    strings,
+    stringContext,
     0,
     [],
   );
@@ -103,7 +103,7 @@ test('Method call with no arguments', t => {
 });
 
 test('Method with arguments', t => {
-  const { stringContext: strings, objectMutationProcessor, sandbox, canvasElement } = t.context;
+  const { stringContext, objectMutationProcessor, sandbox, canvasElement } = t.context;
 
   const methodName = 'fillRect';
   const serializedArgs = [
@@ -128,7 +128,7 @@ test('Method with arguments', t => {
     canvasElement,
     [TransferrableObjectType.CanvasRenderingContext2D, canvasElement._index_],
     methodName,
-    strings,
+    stringContext,
     4,
     serializedArgs,
   );
@@ -136,7 +136,7 @@ test('Method with arguments', t => {
 });
 
 test('Setter', t => {
-  const { stringContext: strings, objectMutationProcessor, sandbox, canvasElement } = t.context;
+  const { stringContext, objectMutationProcessor, sandbox, canvasElement } = t.context;
 
   const methodName = 'lineWidth';
   const setter = sandbox.spy();
@@ -157,7 +157,7 @@ test('Setter', t => {
     canvasElement,
     [TransferrableObjectType.CanvasRenderingContext2D, canvasElement._index_],
     methodName,
-    strings,
+    stringContext,
     1,
     serializedArg,
   );
@@ -165,7 +165,7 @@ test('Setter', t => {
 });
 
 test('Method on prototype', t => {
-  const { stringContext: strings, objectMutationProcessor, sandbox, canvasElement } = t.context;
+  const { stringContext, objectMutationProcessor, sandbox, canvasElement } = t.context;
 
   const methodName = 'fillRect';
   const serializedArgs = [
@@ -192,7 +192,7 @@ test('Method on prototype', t => {
     canvasElement,
     [TransferrableObjectType.CanvasRenderingContext2D, canvasElement._index_],
     methodName,
-    strings,
+    stringContext,
     4,
     serializedArgs,
   );
@@ -200,7 +200,7 @@ test('Method on prototype', t => {
 });
 
 test('Setter on prototype', t => {
-  const { stringContext: strings, objectMutationProcessor, sandbox, canvasElement } = t.context;
+  const { stringContext, objectMutationProcessor, sandbox, canvasElement } = t.context;
 
   const methodName = 'lineWidth';
   const setter = sandbox.spy();
@@ -223,7 +223,7 @@ test('Setter on prototype', t => {
     canvasElement,
     [TransferrableObjectType.CanvasRenderingContext2D, canvasElement._index_],
     methodName,
-    strings,
+    stringContext,
     1,
     serializedArg,
   );
@@ -231,7 +231,7 @@ test('Setter on prototype', t => {
 });
 
 test('Mutation starts at a non-zero offset', t => {
-  const { stringContext: strings, objectMutationProcessor, sandbox, canvasElement } = t.context;
+  const { stringContext, objectMutationProcessor, sandbox, canvasElement } = t.context;
 
   const methodName = 'fillRect';
   const targetObject = canvasElement.getContext('2d');
@@ -255,7 +255,7 @@ test('Mutation starts at a non-zero offset', t => {
 
   const mutation = [
     TransferrableMutationType.OBJECT_MUTATION,
-    storeString(strings, methodName),
+    storeString(stringContext, methodName),
     4, // arg count
     TransferrableObjectType.CanvasRenderingContext2D,
     canvasElement._index_,
@@ -270,7 +270,7 @@ test('Mutation starts at a non-zero offset', t => {
 });
 
 test('Returns correct end offset', t => {
-  const { stringContext: strings, objectMutationProcessor, canvasElement, sandbox } = t.context;
+  const { stringContext, objectMutationProcessor, canvasElement, sandbox } = t.context;
 
   const targetObject = canvasElement.getContext('2d');
 
@@ -293,7 +293,7 @@ test('Returns correct end offset', t => {
 
   const mutation = [
     TransferrableMutationType.OBJECT_MUTATION,
-    storeString(strings, methodName),
+    storeString(stringContext, methodName),
     4, // arg count
     TransferrableObjectType.CanvasRenderingContext2D,
     canvasElement._index_,

--- a/src/worker-thread/WorkerDOMGlobalScope.ts
+++ b/src/worker-thread/WorkerDOMGlobalScope.ts
@@ -58,6 +58,7 @@ export interface GlobalScope {
   localStorage: object;
   location: object;
   url: string;
+  indexedDB: IDBFactory;
   innerWidth: number;
   innerHeight: number;
   MutationObserver: typeof MutationObserver;

--- a/src/worker-thread/WorkerDOMGlobalScope.ts
+++ b/src/worker-thread/WorkerDOMGlobalScope.ts
@@ -58,7 +58,7 @@ export interface GlobalScope {
   localStorage: object;
   location: object;
   url: string;
-  indexedDB: IDBFactory;
+  indexedDB?: IDBFactory;
   innerWidth: number;
   innerHeight: number;
   MutationObserver: typeof MutationObserver;

--- a/src/worker-thread/canvas/OffscreenCanvasPolyfill.ts
+++ b/src/worker-thread/canvas/OffscreenCanvasPolyfill.ts
@@ -347,16 +347,15 @@ class OffscreenCanvasRenderingContext2DPolyfill<ElementType extends HTMLElement>
 
   putImageData() {}
 
-  // THROW and implement async versions
   isPointInPath(): boolean {
-    throw new Error('No synchronous implementation for isPointInPath available.');
+    throw new Error('isPointInPath is not implemented.');
   }
 
   isPointInStroke(): boolean {
-    throw new Error('No synchronous implementation for isPointInStroke available.');
+    throw new Error('isPointInStroke is not implemented.');
   }
 
   measureText(): TextMetrics {
-    throw new Error('No synchronous implementation for measureText available.');
+    throw new Error('measureText is not implemented.');
   }
 }

--- a/src/worker-thread/index.amp.ts
+++ b/src/worker-thread/index.amp.ts
@@ -116,7 +116,6 @@ const WHITELISTED_GLOBALS = [
   'encodeURI',
   'encodeURIComponent',
   'escape',
-  'eval',
   'fetch',
   'indexedDB',
   'isFinite',
@@ -139,6 +138,7 @@ const globalScope: GlobalScope = {
   localStorage: {},
   location: self.location,
   url: '/',
+  indexedDB: (self as WorkerGlobalScope).indexedDB,
   innerWidth: 0,
   innerHeight: 0,
   initialize,
@@ -197,7 +197,6 @@ function updateLongTask(global: WorkerGlobalScope) {
   const originalFetch = global['fetch'];
   if (originalFetch) {
     try {
-      // TODO(choumx): Add origin whitelisting.
       Object.defineProperty(global, 'fetch', {
         enumerable: true,
         writable: true,

--- a/src/worker-thread/index.ts
+++ b/src/worker-thread/index.ts
@@ -57,6 +57,7 @@ const globalScope: GlobalScope = {
   localStorage: {},
   location: {},
   url: '/',
+  indexedDB: (self as WorkerGlobalScope).indexedDB,
   innerWidth: 0,
   innerHeight: 0,
   initialize,


### PR DESCRIPTION
Also rename `Strings` to `StringContext` to be consistent with other "Context" classes, and other minor clean up items.

/to @kristoferbaxter 