### PR TITLE
Move getNode(<target>) inside mutation processors

### DIFF
--- a/src/main-thread/commands/bounding-client-rect.ts
+++ b/src/main-thread/commands/bounding-client-rect.ts
@@ -20,12 +20,16 @@ import { CommandExecutorInterface } from './interface';
 import { BoundClientRectMutationIndex } from '../../transfer/TransferrableBoundClientRect';
 import { TransferrableMutationType } from '../../transfer/TransferrableMutation';
 
+const CONTEXT = 'GET_BOUNDING_CLIENT_RECT';
+
 export const BoundingClientRectProcessor: CommandExecutorInterface = (strings, nodes, workerContext, objectContext, config) => {
   const allowedExecution = config.executorsAllowed.includes(TransferrableMutationType.GET_BOUNDING_CLIENT_RECT);
 
   return {
-    execute(mutations: Uint16Array, startPosition: number, target: RenderableElement): number {
+    execute(mutations: Uint16Array, startPosition: number): number {
       if (allowedExecution) {
+        const targetIndex = mutations[startPosition + BoundClientRectMutationIndex.Target];
+        const target = nodes.getNode(targetIndex);
         if (target) {
           const boundingRect = target.getBoundingClientRect();
           workerContext.messageToWorker({
@@ -41,15 +45,17 @@ export const BoundingClientRectProcessor: CommandExecutorInterface = (strings, n
             ],
           });
         } else {
-          console.error(`getNode() yields null – ${target}`);
+          console.error(`${CONTEXT}: getNode(${targetIndex}) is null.`);
         }
       }
 
       return startPosition + BoundClientRectMutationIndex.End;
     },
-    print(mutations: Uint16Array, startPosition: number, target?: RenderableElement | null): Object {
+    print(mutations: Uint16Array, startPosition: number): Object {
+      const targetIndex = mutations[startPosition + BoundClientRectMutationIndex.Target];
+      const target = nodes.getNode(targetIndex);
       return {
-        type: 'GET_BOUNDING_CLIENT_RECT',
+        type: CONTEXT,
         target,
         allowedExecution,
       };

--- a/src/main-thread/commands/character-data.ts
+++ b/src/main-thread/commands/character-data.ts
@@ -17,21 +17,31 @@
 import { CharacterDataMutationIndex, TransferrableMutationType } from '../../transfer/TransferrableMutation';
 import { CommandExecutorInterface } from './interface';
 
+const CONTEXT = 'CHAR_DATA';
+
 export const CharacterDataProcessor: CommandExecutorInterface = (strings, nodes, workerContext, objectContext, config) => {
   const allowedExecution = config.executorsAllowed.includes(TransferrableMutationType.CHARACTER_DATA);
 
   return {
-    execute(mutations: Uint16Array, startPosition: number, target: RenderableElement): number {
+    execute(mutations: Uint16Array, startPosition: number): number {
       if (allowedExecution) {
+        const targetIndex = mutations[startPosition + CharacterDataMutationIndex.Target];
+        const target = nodes.getNode(targetIndex);
         const value = mutations[startPosition + CharacterDataMutationIndex.Value];
-        if (value) {
-          // Sanitization not necessary for textContent.
-          target.textContent = strings.get(value);
+        if (target) {
+          if (value) {
+            // Sanitization not necessary for textContent.
+            target.textContent = strings.get(value);
+          }
+        } else {
+          console.error(`${CONTEXT}: getNode(${targetIndex}) is null.`);
         }
       }
       return startPosition + CharacterDataMutationIndex.End;
     },
-    print(mutations: Uint16Array, startPosition: number, target?: RenderableElement | null): Object {
+    print(mutations: Uint16Array, startPosition: number): Object {
+      const targetIndex = mutations[startPosition + CharacterDataMutationIndex.Target];
+      const target = nodes.getNode(targetIndex);
       return {
         target,
         allowedExecution,

--- a/src/main-thread/commands/event-subscription.ts
+++ b/src/main-thread/commands/event-subscription.ts
@@ -171,7 +171,7 @@ export const EventSubscriptionProcessor: CommandExecutorInterface = (strings, no
   };
 
   return {
-    execute(mutations: Uint16Array, startPosition: number, target: RenderableElement): number {
+    execute(mutations: Uint16Array, startPosition: number): number {
       const addEventListenerCount = mutations[startPosition + EventSubscriptionMutationIndex.AddEventListenerCount];
       const removeEventListenerCount = mutations[startPosition + EventSubscriptionMutationIndex.RemoveEventListenerCount];
       const addEventListenersPosition = startPosition + EventSubscriptionMutationIndex.Events + removeEventListenerCount * EVENT_SUBSCRIPTION_LENGTH;
@@ -179,12 +179,15 @@ export const EventSubscriptionProcessor: CommandExecutorInterface = (strings, no
         startPosition + EventSubscriptionMutationIndex.Events + (addEventListenerCount + removeEventListenerCount) * EVENT_SUBSCRIPTION_LENGTH;
 
       if (allowedExecution) {
+        const targetIndex = mutations[startPosition + EventSubscriptionMutationIndex.Target];
+        const target = nodeContext.getNode(targetIndex);
+
         if (target) {
           for (let iterator = startPosition + EventSubscriptionMutationIndex.Events; iterator < endPosition; iterator += EVENT_SUBSCRIPTION_LENGTH) {
             processListenerChange(target, iterator <= addEventListenersPosition, strings.get(mutations[iterator]), mutations[iterator + 1]);
           }
         } else {
-          console.error(`getNode() yields null – ${target}`);
+          console.error(`getNode(${targetIndex}) is null.`);
         }
       }
 

--- a/src/main-thread/commands/image-bitmap.ts
+++ b/src/main-thread/commands/image-bitmap.ts
@@ -19,12 +19,16 @@ import { TransferrableMutationType, ImageBitmapMutationIndex } from '../../trans
 import { TransferrableKeys } from '../../transfer/TransferrableKeys';
 import { MessageType } from '../../transfer/Messages';
 
+const CONTEXT = 'IMAGE_BITMAP_INSTANCE';
+
 export const ImageBitmapProcessor: CommandExecutorInterface = (strings, nodeContext, workerContext, objectContext, config) => {
   const allowedExecution = config.executorsAllowed.includes(TransferrableMutationType.IMAGE_BITMAP_INSTANCE);
 
   return {
-    execute(mutations: Uint16Array, startPosition: number, target: RenderableElement): number {
+    execute(mutations: Uint16Array, startPosition: number): number {
       if (allowedExecution) {
+        const targetIndex = mutations[startPosition + ImageBitmapMutationIndex.Target];
+        const target = nodeContext.getNode(targetIndex);
         if (target) {
           self.createImageBitmap(target as HTMLImageElement | HTMLCanvasElement).then(imageBitmap => {
             workerContext.messageToWorker(
@@ -37,15 +41,17 @@ export const ImageBitmapProcessor: CommandExecutorInterface = (strings, nodeCont
             );
           });
         } else {
-          console.error(`getNode() yields null - ${target}`);
+          console.error(`${CONTEXT}: getNode(${targetIndex}) is null.`);
         }
       }
 
       return startPosition + ImageBitmapMutationIndex.End;
     },
-    print(mutations: Uint16Array, startPosition: number, target?: RenderableElement | null): Object {
+    print(mutations: Uint16Array, startPosition: number): Object {
+      const targetIndex = mutations[startPosition + ImageBitmapMutationIndex.Target];
+      const target = nodeContext.getNode(targetIndex);
       return {
-        type: 'IMAGE_BITMAP_INSTANCE',
+        type: CONTEXT,
         target,
         allowedExecution,
         callIndex: mutations[startPosition + ImageBitmapMutationIndex.CallIndex],

--- a/src/main-thread/commands/interface.ts
+++ b/src/main-thread/commands/interface.ts
@@ -21,8 +21,8 @@ import { WorkerContext } from '../worker';
 import { ObjectContext } from '../object-context';
 
 export interface CommandExecutor {
-  execute(mutations: Uint16Array, startPosition: number, target?: RenderableElement): number;
-  print(mutations: Uint16Array, startPosition: number, target?: RenderableElement | null): Object;
+  execute(mutations: Uint16Array, startPosition: number): number;
+  print(mutations: Uint16Array, startPosition: number): Object;
 }
 
 export interface CommandExecutorInterface {

--- a/src/main-thread/commands/long-task.ts
+++ b/src/main-thread/commands/long-task.ts
@@ -47,7 +47,7 @@ export const LongTaskExecutor: LongTaskCommandExecutorInterface = (
   let currentResolver: Function | null;
 
   return {
-    execute(mutations: Uint16Array, startPosition: number, target: RenderableElement): number {
+    execute(mutations: Uint16Array, startPosition: number): number {
       if (allowedExecution && config.longTask) {
         if (mutations[startPosition] === TransferrableMutationType.LONG_TASK_START) {
           index++;
@@ -65,7 +65,7 @@ export const LongTaskExecutor: LongTaskCommandExecutorInterface = (
       }
       return startPosition + LongTaskMutationIndex.End;
     },
-    print(mutations: Uint16Array, startPosition: number, target?: RenderableElement | null): Object {
+    print(mutations: Uint16Array, startPosition: number): Object {
       return {
         type: ReadableMutationType[mutations[startPosition]],
         allowedExecution,

--- a/src/main-thread/commands/object-creation.ts
+++ b/src/main-thread/commands/object-creation.ts
@@ -53,7 +53,7 @@ export const ObjectCreationProcessor: CommandExecutorInterface = (strings, nodeC
 
       return argsOffset;
     },
-    print(mutations: Uint16Array, startPosition: number, target?: RenderableElement | null): Object {
+    print(mutations: Uint16Array, startPosition: number): Object {
       const functionName = strings.get(mutations[startPosition + ObjectCreationIndex.FunctionName]);
       const objectId = mutations[startPosition + ObjectCreationIndex.ObjectId];
       const argCount = mutations[startPosition + ObjectCreationIndex.ArgumentCount];
@@ -66,7 +66,7 @@ export const ObjectCreationProcessor: CommandExecutorInterface = (strings, nodeC
         nodeContext,
         objectContext,
       );
-      target = deserializedTarget[0] as RenderableElement;
+      const target = deserializedTarget[0] as RenderableElement;
 
       return {
         type: 'OBJECT_CREATION',

--- a/src/main-thread/commands/object-mutation.ts
+++ b/src/main-thread/commands/object-mutation.ts
@@ -48,7 +48,7 @@ export const ObjectMutationProcessor: CommandExecutorInterface = (strings, nodeC
 
       return argsOffset;
     },
-    print(mutations: Uint16Array, startPosition: number, target?: RenderableElement | null): Object {
+    print(mutations: Uint16Array, startPosition: number): Object {
       const functionName = strings.get(mutations[startPosition + ObjectMutationIndex.FunctionName]);
       const { args: deserializedTarget } = deserializeTransferrableObject(
         mutations,
@@ -58,7 +58,7 @@ export const ObjectMutationProcessor: CommandExecutorInterface = (strings, nodeC
         nodeContext,
         objectContext,
       );
-      target = deserializedTarget[0] as RenderableElement;
+      const target = deserializedTarget[0] as RenderableElement;
 
       return {
         type: 'OBJECT_MUTATION',

--- a/src/main-thread/commands/offscreen-canvas.ts
+++ b/src/main-thread/commands/offscreen-canvas.ts
@@ -19,12 +19,16 @@ import { MessageType } from '../../transfer/Messages';
 import { CommandExecutorInterface } from './interface';
 import { OffscreenCanvasMutationIndex, TransferrableMutationType } from '../../transfer/TransferrableMutation';
 
+const CONTEXT = 'OFFSCREEN_CANVAS_INSTANCE';
+
 export const OffscreenCanvasProcessor: CommandExecutorInterface = (strings, nodeContext, workerContext, objectContext, config) => {
   const allowedExecution = config.executorsAllowed.includes(TransferrableMutationType.OFFSCREEN_CANVAS_INSTANCE);
 
   return {
-    execute(mutations: Uint16Array, startPosition: number, target: RenderableElement): number {
+    execute(mutations: Uint16Array, startPosition: number): number {
       if (allowedExecution) {
+        const targetIndex = mutations[startPosition + OffscreenCanvasMutationIndex.Target];
+        const target = nodeContext.getNode(targetIndex);
         if (target) {
           const offscreen = (target as HTMLCanvasElement).transferControlToOffscreen();
           workerContext.messageToWorker(
@@ -36,7 +40,7 @@ export const OffscreenCanvasProcessor: CommandExecutorInterface = (strings, node
             [offscreen],
           );
         } else {
-          console.error(`getNode() yields null – ${target}`);
+          console.error(`${CONTEXT}: getNode(${targetIndex}) is null.`);
         }
       }
 
@@ -44,7 +48,7 @@ export const OffscreenCanvasProcessor: CommandExecutorInterface = (strings, node
     },
     print(mutations: Uint16Array, startPosition: number, target?: RenderableElement | null): Object {
       return {
-        type: 'OFFSCREEN_CANVAS_INSTANCE',
+        type: CONTEXT,
         target,
         allowedExecution,
       };

--- a/src/main-thread/mutator.ts
+++ b/src/main-thread/mutator.ts
@@ -114,27 +114,11 @@ export class MutatorProcessor {
 
       while (operationStart < length) {
         const mutationType = mutationArray[operationStart];
-
-        if (mutationType === TransferrableMutationType.OBJECT_MUTATION || mutationType === TransferrableMutationType.OBJECT_CREATION) {
-          if (DEBUG_ENABLED) {
-            console.log(ReadableMutationType[mutationType], this.executors[mutationType].print(mutationArray, operationStart));
-          }
-          operationStart = this.executors[mutationType].execute(mutationArray, operationStart);
-
-          // TODO: remove conditional branching by moving `target = nodeContext.getNode(...)` into
-          // the processors that require it.
-        } else {
-          const target = this.nodeContext.getNode(mutationArray[operationStart + 1]);
-
-          if (!target) {
-            console.error(`getNode() yields null – ${target}`);
-            return;
-          }
-          if (DEBUG_ENABLED) {
-            console.log(ReadableMutationType[mutationType], this.executors[mutationType].print(mutationArray, operationStart, target));
-          }
-          operationStart = this.executors[mutationType].execute(mutationArray, operationStart, target);
+        const executor = this.executors[mutationType];
+        if (DEBUG_ENABLED) {
+          console.log(ReadableMutationType[mutationType], executor.print(mutationArray, operationStart));
         }
+        operationStart = executor.execute(mutationArray, operationStart);
       }
     });
     if (DEBUG_ENABLED) {

--- a/src/test/main-thread/long-task.test.ts
+++ b/src/test/main-thread/long-task.test.ts
@@ -94,20 +94,20 @@ test.serial('should tolerate no callback', t => {
     }),
   );
 
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, baseElement);
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, baseElement);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0);
   t.is(longTasks.length, 0);
 });
 
 test.serial('should create and release a long task', t => {
   const { executor, longTasks, baseElement } = t.context;
 
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, baseElement);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // Ensure the promise is resolved in the end.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, baseElement);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0);
   t.is(longTasks.length, 1);
   t.false(executor.active);
   return longTasks[0];
@@ -116,22 +116,22 @@ test.serial('should create and release a long task', t => {
 test.serial('should nest long tasks', t => {
   const { executor, longTasks, baseElement } = t.context;
 
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, baseElement);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // Nested: no new promise/task created.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, baseElement);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // Unnest: the task is still active.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, baseElement);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // Ensure the promise is resolved in the end.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, baseElement);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0);
   t.is(longTasks.length, 1);
   t.false(executor.active);
   return longTasks[0];
@@ -141,22 +141,22 @@ test.serial('should restart a next long tasks', t => {
   const { executor, longTasks, baseElement } = t.context;
 
   // Start 1st task.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, baseElement);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // End 1st task.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, baseElement);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0);
   t.is(longTasks.length, 1);
   t.false(executor.active);
 
   // Start 2nd task.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, baseElement);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0);
   t.is(longTasks.length, 2);
   t.true(executor.active);
 
   // End 2nd task.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, baseElement);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0);
   t.is(longTasks.length, 2);
   t.false(executor.active);
 

--- a/src/test/main-thread/object-creation.test.ts
+++ b/src/test/main-thread/object-creation.test.ts
@@ -115,7 +115,6 @@ test('Object creation with mutation at a zero offset', t => {
       ...serializedArgs,
     ]),
     0,
-    canvasElement,
   );
 
   t.true(stub.withArgs(1, 2, 3, 4).calledOnce);
@@ -163,7 +162,7 @@ test('Object creation with mutation at non-zero offset', t => {
 
   // add three values to the start of the mutation and change the offset
   const mutationsArray = new Uint16Array([1, 2, 3].concat(mutation));
-  objectCreationProcessor.execute(mutationsArray, 3, canvasElement);
+  objectCreationProcessor.execute(mutationsArray, 3);
 
   t.true(stub.withArgs(1, 2, 3, 4).calledOnce);
   t.is(objectContext.get(objectId), gradientObject);
@@ -205,7 +204,7 @@ test('Returns correct end offset', t => {
   ];
 
   const mutationsArray = new Uint16Array([1, 2, 3].concat(mutation));
-  const endOffset = objectCreationProcessor.execute(mutationsArray, 3, canvasElement);
+  const endOffset = objectCreationProcessor.execute(mutationsArray, 3);
 
   t.is(mutationsArray[endOffset], 32);
 });

--- a/src/test/main-thread/object-mutation.test.ts
+++ b/src/test/main-thread/object-mutation.test.ts
@@ -264,7 +264,7 @@ test('Mutation starts at a non-zero offset', t => {
 
   // add three values to the start of the mutation and change the offset
   const mutationsArray = new Uint16Array([1, 2, 3].concat(mutation));
-  objectMutationProcessor.execute(mutationsArray, 3, canvasElement);
+  objectMutationProcessor.execute(mutationsArray, 3);
 
   t.true(stub.withArgs(...args).calledOnce);
 });
@@ -304,7 +304,7 @@ test('Returns correct end offset', t => {
   ];
 
   const mutationsArray = new Uint16Array([1, 2, 3].concat(mutation));
-  const endOffset = objectMutationProcessor.execute(mutationsArray, 3, canvasElement);
+  const endOffset = objectMutationProcessor.execute(mutationsArray, 3);
 
   t.is(mutationsArray[endOffset], 32);
 });
@@ -328,7 +328,6 @@ function executeCall(
       ...serializedArgs,
     ]),
     0,
-    target,
   );
 }
 


### PR DESCRIPTION
Small refactor that moves the retrieval of "target" element inside each mutation processor. 

This is desirable since we have new processors that don't require a target element (e.g. localStorage).

/to @kristoferbaxter 