### PR TITLE
Upgrade TS to 3.5.3 and fix some bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "sinon": "7.3.2",
     "sirv": "0.4.2",
     "tslint": "5.18.0",
-    "typescript": "3.4.5"
+    "typescript": "3.5.3"
   },
   "lint-staged": {
     "*.{js,ts}": [

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     {
       "path": "./dist/worker/worker.mjs",
       "compression": "brotli",
-      "maxSize": "10.95 kB"
+      "maxSize": "11.0 kB"
     },
     {
       "path": "./dist/worker/worker.js",

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -86,6 +86,6 @@ export class WorkerContext {
     if (this.config.onSendMessage) {
       this.config.onSendMessage(message);
     }
-    this.worker.postMessage(message, transferables);
+    this.worker.postMessage(message, transferables || []);
   }
 }

--- a/src/worker-thread/WorkerDOMGlobalScope.ts
+++ b/src/worker-thread/WorkerDOMGlobalScope.ts
@@ -91,6 +91,8 @@ export interface GlobalScope {
   HTMLTableRowElement: typeof HTMLTableRowElement;
   HTMLTableSectionElement: typeof HTMLTableSectionElement;
   HTMLTimeElement: typeof HTMLTimeElement;
+  OffscreenCanvas?: typeof OffscreenCanvas;
+  ImageBitmap?: typeof ImageBitmap;
 }
 
 export interface WorkerDOMGlobalScope extends GlobalScope {

--- a/src/worker-thread/canvas/CanvasRenderingContext2D.ts
+++ b/src/worker-thread/canvas/CanvasRenderingContext2D.ts
@@ -96,7 +96,7 @@ export class CanvasRenderingContext2DShim<ElementType extends HTMLElement> imple
           data[TransferrableKeys.type] === MessageType.OFFSCREEN_CANVAS_INSTANCE &&
           data[TransferrableKeys.target][0] === canvas[TransferrableKeys.index]
         ) {
-          document.removeRemoveEventListener('message', messageHandler);
+          document.removeGlobalEventListener('message', messageHandler);
           const transferredOffscreenCanvas = (data as OffscreenCanvasToWorker)[TransferrableKeys.data];
           resolve(transferredOffscreenCanvas as { getContext(c: '2d'): CanvasRenderingContext2D });
         }

--- a/src/worker-thread/canvas/OffscreenCanvasPolyfill.ts
+++ b/src/worker-thread/canvas/OffscreenCanvasPolyfill.ts
@@ -25,6 +25,7 @@ import {
   CanvasLineJoin,
   CanvasDirection,
   CanvasFillRule,
+  CanvasImageSource,
 } from './CanvasTypes';
 import { transfer } from '../MutationTransfer';
 import { Document } from '../dom/Document';

--- a/src/worker-thread/dom/Node.ts
+++ b/src/worker-thread/dom/Node.ts
@@ -47,7 +47,7 @@ export const propagate = (node: Node, property: string | number, value: any): vo
 // This is intentional to reduce the number of classes.
 
 export abstract class Node {
-  [index: string]: any;
+  [index: string]: any; // TODO(choumx): Remove this typing escape hatch.
   public ownerDocument: Node; // TODO(choumx): Should be a Document.
   // https://drafts.csswg.org/selectors-4/#scoping-root
   public [TransferrableKeys.scopingRoot]: Node;

--- a/src/worker-thread/index.ts
+++ b/src/worker-thread/index.ts
@@ -100,6 +100,11 @@ export const workerDOM = (function(postMessage, addEventListener, removeEventLis
   document.addGlobalEventListener = addEventListener;
   document.removeGlobalEventListener = removeEventListener;
 
+  // Canvas's use of native OffscreenCanvas checks the existence of the property
+  // on the WorkerDOMGlobalScope.
+  globalScope.OffscreenCanvas = (self as any)['OffscreenCanvas'];
+  globalScope.ImageBitmap = (self as any)['ImageBitmap'];
+
   document.isConnected = true;
   document.appendChild((document.body = document.createElement('body')));
   return document.defaultView;


### PR DESCRIPTION
I suspect #578 broke native OffscreenCanvas but the examples tested fine manually because of the polyfill case. More digging to do here.

First, going to fix the `ownerDocument: Node` type issue which results in `ownerDocument.defaultView.foo` being typed as `any` due to [the escape hatch](https://github.com/ampproject/worker-dom/pull/578#discussion_r303655032) in `Node`.