### PR TITLE
WebSocket Support for AMP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/worker-dom",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A facsimile of a modern DOM implementation intended to run in a Web Worker.",
   "main": "dist/main",
   "files": [

--- a/src/worker-thread/index.amp.ts
+++ b/src/worker-thread/index.amp.ts
@@ -111,6 +111,7 @@ const ALLOWLISTED_GLOBALS: { [key: string]: boolean } = {
   WeakMap: true,
   WeakSet: true,
   WebAssembly: true,
+  WebSocket: true,
   XMLHttpRequest: true,
   atob: true,
   addEventListener: true,


### PR DESCRIPTION
WebSockets were not on the Allowlist for the AMP version of the WorkerThread. 