### PR TITLE
Node constants

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,12 +92,12 @@
     {
       "path": "./dist/worker/worker.mjs",
       "compression": "brotli",
-      "maxSize": "11.2 kB"
+      "maxSize": "11.4 kB"
     },
     {
       "path": "./dist/worker/worker.js",
       "compression": "brotli",
-      "maxSize": "12.4 kB"
+      "maxSize": "12.6 kB"
     },
     {
       "path": "./dist/main.mjs",

--- a/src/worker-thread/dom/Node.ts
+++ b/src/worker-thread/dom/Node.ts
@@ -47,6 +47,24 @@ export const propagate = (node: Node, property: string | number, value: any): vo
 // This is intentional to reduce the number of classes.
 
 export abstract class Node {
+  public static readonly ELEMENT_NODE = 1;
+  public static readonly ATTRIBUTE_NODE = 2;
+  public static readonly TEXT_NODE = 3;
+  public static readonly CDATA_SECTION_NODE = 4;
+  public static readonly ENTITY_REFERENCE_NODE = 5;
+  public static readonly ENTITY_NODE = 6;
+  public static readonly PROCESSING_INSTRUCTION_NODE = 7;
+  public static readonly COMMENT_NODE = 8;
+  public static readonly DOCUMENT_NODE = 9;
+  public static readonly DOCUMENT_TYPE_NODE = 10;
+  public static readonly DOCUMENT_FRAGMENT_NODE = 11;
+  public static readonly NOTATION_NODE = 12;
+  public static readonly DOCUMENT_POSITION_DISCONNECTED = 1;
+  public static readonly DOCUMENT_POSITION_PRECEDING = 2;
+  public static readonly DOCUMENT_POSITION_FOLLOWING = 4;
+  public static readonly DOCUMENT_POSITION_CONTAINS = 8;
+  public static readonly DOCUMENT_POSITION_CONTAINED_BY = 16;
+  public static readonly DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 32;
   [index: string]: any; // TODO(choumx): Remove this typing escape hatch.
   public ownerDocument: Node; // TODO(choumx): Should be a Document.
   // https://drafts.csswg.org/selectors-4/#scoping-root


### PR DESCRIPTION
Starting to add APIs needed for #19. Some of these constants are deprecated. Would you rather leave those out?

![image](https://user-images.githubusercontent.com/1306747/63645210-ef6c3a00-c6ad-11e9-9478-f42d1b56f844.png)
https://developer.mozilla.org/en-US/docs/Web/API/Node