### PR TITLE
Global event handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     {
       "path": "./dist/worker/worker.mjs",
       "compression": "brotli",
-      "maxSize": "11.2 kB"
+      "maxSize": "11.3 kB"
     },
     {
       "path": "./dist/worker/worker.js",

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -39,15 +39,20 @@ export class WorkerContext {
     this.config = config;
 
     const { skeleton, strings } = createHydrateableRootNode(baseElement, config, this);
-
     const cssKeys: Array<string> = [];
-    for (const key in baseElement.style) {
-      cssKeys.push(key);
-    }
-
+    const globalEventHandlerKeys: Array<string> = [];
     // TODO(choumx): Sync read of all localStorage and sessionStorage a possible performance bottleneck?
     const localStorageData = config.sanitizer ? config.sanitizer.getStorage(StorageLocation.Local) : window.localStorage;
     const sessionStorageData = config.sanitizer ? config.sanitizer.getStorage(StorageLocation.Session) : window.sessionStorage;
+
+    for (const key in baseElement.style) {
+      cssKeys.push(key);
+    }
+    for (const key in baseElement) {
+      if (key.startsWith('on')) {
+        globalEventHandlerKeys.push(key);
+      }
+    }
 
     const code = `
       'use strict';
@@ -60,6 +65,7 @@ export class WorkerContext {
           ${JSON.stringify(strings)},
           ${JSON.stringify(skeleton)},
           ${JSON.stringify(cssKeys)},
+          ${JSON.stringify(globalEventHandlerKeys)},
           [${window.innerWidth}, ${window.innerHeight}],
           ${JSON.stringify(localStorageData)},
           ${JSON.stringify(sessionStorageData)}

--- a/src/test/htmlelement/globalEventProperties.test.ts
+++ b/src/test/htmlelement/globalEventProperties.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import anyTest, { TestInterface } from 'ava';
+import { HTMLElement, appendGlobalEventProperties } from '../../worker-thread/dom/HTMLElement';
+import { createTestingDocument } from '../DocumentCreation';
+import { Document } from '../../worker-thread/dom/Document';
+import { TransferrableKeys } from '../../transfer/TransferrableKeys';
+
+const test = anyTest as TestInterface<{
+  document: Document;
+  element: HTMLElement;
+}>;
+
+test.beforeEach(t => {
+  const document = createTestingDocument();
+
+  t.context = {
+    document,
+    element: document.createElement('div') as HTMLElement,
+  };
+});
+
+test.serial('appending keys mutates existing instance', t => {
+  const { element } = t.context;
+
+  t.is(element.onclick, undefined);
+  appendGlobalEventProperties(['onclick']);
+  t.is(element.onclick, null);
+});
+
+test.serial('previously appended keys should exist on newly created instances', t => {
+  const { document } = t.context;
+  const newElement = document.createElement('div');
+
+  t.is(newElement.onclick, null);
+});
+
+test.serial('subscription uses only assigned value', t => {
+  const { element } = t.context;
+  const handler = (e: any) => console.log(e);
+
+  t.is(element.onclick, null);
+  element.onclick = handler;
+  t.is(element.onclick, handler);
+});
+
+test.serial('subscription uses only last assigned value', t => {
+  const { element } = t.context;
+  const handler = (e: any) => console.log('one', e);
+  const handlerTwo = (e: any) => console.log('two', e);
+
+  t.is(element.onclick, null);
+  element.onclick = handler;
+  t.is(element.onclick, handler);
+  element.onclick = handlerTwo;
+  t.is(element.onclick, handlerTwo);
+});
+
+test('appending keys mutates all known instances', t => {
+  const { document } = t.context;
+  const firstElement = document.createElement('div');
+  const secondElement = document.createElement('div');
+
+  t.is(firstElement.onmouseenter, undefined);
+  t.is(secondElement.onmouseenter, undefined);
+  appendGlobalEventProperties(['onmouseenter']);
+  t.is(firstElement.onmouseenter, null);
+  t.is(secondElement.onmouseenter, null);
+});
+
+test('reappending a key does not cause an error', t => {
+  const { element } = t.context;
+  appendGlobalEventProperties(['onmouseexit']);
+  appendGlobalEventProperties(['onmouseexit']);
+
+  t.is(element.onmouseexit, null);
+});
+
+test('appending as many keys as there are TransferrableKeys functions', t => {
+  const { element } = t.context;
+  const handler = (e: any) => console.log(e);
+  appendGlobalEventProperties(['ontouchmove']);
+  appendGlobalEventProperties(Array.from(Array(TransferrableKeys.END), (d, i) => i + 'key'));
+
+  t.is(element.ontouchmove, null);
+  element.ontouchmove = handler;
+  t.is(element.ontouchmove, handler);
+});

--- a/src/transfer/TransferrableKeys.ts
+++ b/src/transfer/TransferrableKeys.ts
@@ -91,6 +91,7 @@ export const enum TransferrableKeys {
   callIndex = 73,
   storageKey = 74,
   storageLocation = 75,
+  propertyEventHandlers = 76,
   // This must always be the last numerically ordered Key, for testing purposes.
   END = 76,
 }

--- a/src/worker-thread/initialize.ts
+++ b/src/worker-thread/initialize.ts
@@ -21,17 +21,20 @@ import { TransferrableKeys } from '../transfer/TransferrableKeys';
 import { appendKeys as addCssKeys } from './css/CSSStyleDeclaration';
 import { createStorage } from './Storage';
 import { StorageLocation } from '../transfer/TransferrableStorage';
+import { appendGlobalEventProperties } from './dom/HTMLElement';
 
 export function initialize(
   document: Document,
   strings: Array<string>,
   hydrateableNode: HydrateableNode,
   cssKeys: Array<string>,
+  globalEventHandlerKeys: Array<string>,
   [innerWidth, innerHeight]: [number, number],
   localStorageData: { [key: string]: string },
   sessionStorageData: { [key: string]: string },
 ): void {
   addCssKeys(cssKeys);
+  appendGlobalEventProperties(globalEventHandlerKeys);
   strings.forEach(storeString);
   (hydrateableNode[TransferrableKeys.childNodes] || []).forEach(child =>
     document.body.appendChild(document[TransferrableKeys.hydrateNode](strings, child)),


### PR DESCRIPTION
Implement Global Event Handlers, frequently used by Frameworks to determine which events need special lower-casing of event names.

https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers

Implemented directly on `HTMLElement` since this appears to be the detection logic for Preact.