### PR TITLE
Remove Blob from Allowlisted Globals

### DIFF
--- a/src/worker-thread/index.amp.ts
+++ b/src/worker-thread/index.amp.ts
@@ -63,7 +63,6 @@ import { wrap as longTaskWrap } from './long-task';
 const ALLOWLISTED_GLOBALS: { [key: string]: boolean } = {
   Array: true,
   ArrayBuffer: true,
-  Blob: true,
   BigInt: true,
   BigInt64Array: true,
   BigUint64Array: true,


### PR DESCRIPTION
Remove `Blob` from allowlist in the AMP output.