### PR TITLE
Allow filtering mutation executions on user-visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,12 +102,12 @@
     {
       "path": "./dist/main.mjs",
       "compression": "brotli",
-      "maxSize": "3.4 kB"
+      "maxSize": "3.5 kB"
     },
     {
       "path": "./dist/main.js",
       "compression": "brotli",
-      "maxSize": "4.0 kB"
+      "maxSize": "4.1 kB"
     }
   ],
   "esm": {

--- a/src/main-thread/commands/attribute.ts
+++ b/src/main-thread/commands/attribute.ts
@@ -32,8 +32,8 @@ export const AttributeProcessor: CommandExecutorInterface = (strings, nodes, wor
   };
 
   return {
-    execute(mutations: Uint16Array, startPosition: number): number {
-      if (allowedExecution) {
+    execute(mutations: Uint16Array, startPosition: number, allowedMutation: boolean): number {
+      if (allowedExecution && allowedMutation) {
         const targetIndex = mutations[startPosition + AttributeMutationIndex.Target];
         const target = nodes.getNode(targetIndex);
 

--- a/src/main-thread/commands/bounding-client-rect.ts
+++ b/src/main-thread/commands/bounding-client-rect.ts
@@ -24,8 +24,8 @@ export const BoundingClientRectProcessor: CommandExecutorInterface = (strings, n
   const allowedExecution = config.executorsAllowed.includes(TransferrableMutationType.GET_BOUNDING_CLIENT_RECT);
 
   return {
-    execute(mutations: Uint16Array, startPosition: number): number {
-      if (allowedExecution) {
+    execute(mutations: Uint16Array, startPosition: number, allowedMutation: boolean): number {
+      if (allowedExecution && allowedMutation) {
         const targetIndex = mutations[startPosition + BoundClientRectMutationIndex.Target];
         const target = nodes.getNode(targetIndex);
         if (target) {

--- a/src/main-thread/commands/character-data.ts
+++ b/src/main-thread/commands/character-data.ts
@@ -21,8 +21,8 @@ export const CharacterDataProcessor: CommandExecutorInterface = (strings, nodes,
   const allowedExecution = config.executorsAllowed.includes(TransferrableMutationType.CHARACTER_DATA);
 
   return {
-    execute(mutations: Uint16Array, startPosition: number): number {
-      if (allowedExecution) {
+    execute(mutations: Uint16Array, startPosition: number, allowedMutation: boolean): number {
+      if (allowedExecution && allowedMutation) {
         const targetIndex = mutations[startPosition + CharacterDataMutationIndex.Target];
         const target = nodes.getNode(targetIndex);
         const value = mutations[startPosition + CharacterDataMutationIndex.Value];

--- a/src/main-thread/commands/child-list.ts
+++ b/src/main-thread/commands/child-list.ts
@@ -23,10 +23,10 @@ export const ChildListProcessor: CommandExecutorInterface = (strings, { getNode 
   const allowedExecution = config.executorsAllowed.includes(TransferrableMutationType.CHILD_LIST);
 
   return {
-    execute(mutations: Uint16Array, startPosition: number): number {
+    execute(mutations: Uint16Array, startPosition: number, allowedMutation: boolean): number {
       const appendNodeCount = mutations[startPosition + ChildListMutationIndex.AppendedNodeCount];
       const removeNodeCount = mutations[startPosition + ChildListMutationIndex.RemovedNodeCount];
-      if (allowedExecution) {
+      if (allowedExecution && allowedMutation) {
         const targetIndex = mutations[startPosition + ChildListMutationIndex.Target];
         const target = getNode(targetIndex);
         if (target) {

--- a/src/main-thread/commands/event-subscription.ts
+++ b/src/main-thread/commands/event-subscription.ts
@@ -205,7 +205,7 @@ export const EventSubscriptionProcessor: CommandExecutorInterface = (strings, no
   };
 
   return {
-    execute(mutations: Uint16Array, startPosition: number): number {
+    execute(mutations: Uint16Array, startPosition: number, allowedMutation: boolean): number {
       const addEventListenerCount = mutations[startPosition + EventSubscriptionMutationIndex.AddEventListenerCount];
       const removeEventListenerCount = mutations[startPosition + EventSubscriptionMutationIndex.RemoveEventListenerCount];
       const addEventListenersPosition =
@@ -216,7 +216,7 @@ export const EventSubscriptionProcessor: CommandExecutorInterface = (strings, no
         addEventListenerCount * ADD_EVENT_SUBSCRIPTION_LENGTH +
         removeEventListenerCount * REMOVE_EVENT_SUBSCRIPTION_LENGTH;
 
-      if (allowedExecution) {
+      if (allowedExecution && allowedMutation) {
         const targetIndex = mutations[startPosition + EventSubscriptionMutationIndex.Target];
         const target = nodeContext.getNode(targetIndex);
 

--- a/src/main-thread/commands/image-bitmap.ts
+++ b/src/main-thread/commands/image-bitmap.ts
@@ -23,8 +23,8 @@ export const ImageBitmapProcessor: CommandExecutorInterface = (strings, nodeCont
   const allowedExecution = config.executorsAllowed.includes(TransferrableMutationType.IMAGE_BITMAP_INSTANCE);
 
   return {
-    execute(mutations: Uint16Array, startPosition: number): number {
-      if (allowedExecution) {
+    execute(mutations: Uint16Array, startPosition: number, allowedMutation: boolean): number {
+      if (allowedExecution && allowedMutation) {
         const targetIndex = mutations[startPosition + ImageBitmapMutationIndex.Target];
         const target = nodeContext.getNode(targetIndex);
         if (target) {

--- a/src/main-thread/commands/interface.ts
+++ b/src/main-thread/commands/interface.ts
@@ -21,7 +21,15 @@ import { WorkerContext } from '../worker';
 import { ObjectContext } from '../object-context';
 
 export interface CommandExecutor {
-  execute(mutations: Uint16Array, startPosition: number): number;
+  /**
+   * If `allow` is true, executes `mutations[startPosition]`. Otherwise, noop.
+   * @param mutations
+   * @param startPosition
+   * @param allow
+   * @return The index (startPosition) of the next mutation.
+   */
+  execute(mutations: Uint16Array, startPosition: number, allow: boolean): number;
+
   print(mutations: Uint16Array, startPosition: number): Object;
 }
 

--- a/src/main-thread/commands/long-task.ts
+++ b/src/main-thread/commands/long-task.ts
@@ -47,8 +47,8 @@ export const LongTaskExecutor: LongTaskCommandExecutorInterface = (
   let currentResolver: Function | null;
 
   return {
-    execute(mutations: Uint16Array, startPosition: number): number {
-      if (allowedExecution && config.longTask) {
+    execute(mutations: Uint16Array, startPosition: number, allowedMutation: boolean): number {
+      if (allowedExecution && allowedMutation && config.longTask) {
         if (mutations[startPosition] === TransferrableMutationType.LONG_TASK_START) {
           index++;
           if (!currentResolver) {

--- a/src/main-thread/commands/object-creation.ts
+++ b/src/main-thread/commands/object-creation.ts
@@ -26,7 +26,7 @@ export const ObjectCreationProcessor: CommandExecutorInterface = (strings, nodeC
   }
 
   return {
-    execute(mutations: Uint16Array, startPosition: number): number {
+    execute(mutations: Uint16Array, startPosition: number, allowedMutation: boolean): number {
       const functionName = strings.get(mutations[startPosition + ObjectCreationIndex.FunctionName]);
       const objectId = mutations[startPosition + ObjectCreationIndex.ObjectId];
       const argCount = mutations[startPosition + ObjectCreationIndex.ArgumentCount];
@@ -43,7 +43,7 @@ export const ObjectCreationProcessor: CommandExecutorInterface = (strings, nodeC
 
       const { offset: argsOffset, args } = deserializeTransferrableObject(mutations, targetOffset, argCount, strings, nodeContext, objectContext);
 
-      if (allowedExecution) {
+      if (allowedExecution && allowedMutation) {
         if (functionName === 'new') {
           // deal with constructor case here
         } else {

--- a/src/main-thread/commands/object-mutation.ts
+++ b/src/main-thread/commands/object-mutation.ts
@@ -22,7 +22,7 @@ export const ObjectMutationProcessor: CommandExecutorInterface = (strings, nodeC
   const allowedExecution = config.executorsAllowed.includes(TransferrableMutationType.OBJECT_MUTATION);
 
   return {
-    execute(mutations: Uint16Array, startPosition: number): number {
+    execute(mutations: Uint16Array, startPosition: number, allowedMutation: boolean): number {
       const functionName = strings.get(mutations[startPosition + ObjectMutationIndex.FunctionName]);
       const argCount = mutations[startPosition + ObjectMutationIndex.ArgumentCount];
 
@@ -38,7 +38,7 @@ export const ObjectMutationProcessor: CommandExecutorInterface = (strings, nodeC
 
       const { offset: argsOffset, args } = deserializeTransferrableObject(mutations, targetOffset, argCount, strings, nodeContext, objectContext);
 
-      if (allowedExecution) {
+      if (allowedExecution && allowedMutation) {
         if (isSetter(target, functionName)) {
           target[functionName] = args[0];
         } else {

--- a/src/main-thread/commands/offscreen-canvas.ts
+++ b/src/main-thread/commands/offscreen-canvas.ts
@@ -23,8 +23,8 @@ export const OffscreenCanvasProcessor: CommandExecutorInterface = (strings, node
   const allowedExecution = config.executorsAllowed.includes(TransferrableMutationType.OFFSCREEN_CANVAS_INSTANCE);
 
   return {
-    execute(mutations: Uint16Array, startPosition: number): number {
-      if (allowedExecution) {
+    execute(mutations: Uint16Array, startPosition: number, allowedMutation: boolean): number {
+      if (allowedExecution && allowedMutation) {
         const targetIndex = mutations[startPosition + OffscreenCanvasMutationIndex.Target];
         const target = nodeContext.getNode(targetIndex);
         if (target) {

--- a/src/main-thread/commands/property.ts
+++ b/src/main-thread/commands/property.ts
@@ -33,8 +33,8 @@ export const PropertyProcessor: CommandExecutorInterface = (strings, nodeContext
   };
 
   return {
-    execute(mutations: Uint16Array, startPosition: number): number {
-      if (allowedExecution) {
+    execute(mutations: Uint16Array, startPosition: number, allowedMutation: boolean): number {
+      if (allowedExecution && allowedMutation) {
         const targetIndex = mutations[startPosition + PropertyMutationIndex.Target];
         const target = nodeContext.getNode(targetIndex);
         const name = strings.get(mutations[startPosition + PropertyMutationIndex.Name]);

--- a/src/main-thread/commands/storage.ts
+++ b/src/main-thread/commands/storage.ts
@@ -71,8 +71,8 @@ export const StorageProcessor: CommandExecutorInterface = (strings, nodeContext,
   };
 
   return {
-    execute(mutations: Uint16Array, startPosition: number): number {
-      if (allowedExecution) {
+    execute(mutations: Uint16Array, startPosition: number, allowedMutation: boolean): number {
+      if (allowedExecution && allowedMutation) {
         const operation = mutations[startPosition + StorageMutationIndex.Operation];
         const location = mutations[startPosition + StorageMutationIndex.Location];
         const keyIndex = mutations[startPosition + StorageMutationIndex.Key];

--- a/src/main-thread/mutator.ts
+++ b/src/main-thread/mutator.ts
@@ -113,8 +113,10 @@ export class MutatorProcessor {
    * Investigations in using asyncFlush to resolve are worth considering.
    *
    * TODO(amphtml): Consider returning the disallowed mutations for better error messaging.
+   *
+   * @param allowVisibleMutations
    */
-  private syncFlush = (allowVisibleMutations: boolean): void => {
+  private syncFlush = (allowVisibleMutations: boolean = true): void => {
     if (WORKER_DOM_DEBUG) {
       console.group('Mutations');
     }

--- a/src/test/main-thread/long-task.test.ts
+++ b/src/test/main-thread/long-task.test.ts
@@ -94,20 +94,20 @@ test.serial('should tolerate no callback', t => {
     }),
   );
 
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0);
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
   t.is(longTasks.length, 0);
 });
 
 test.serial('should create and release a long task', t => {
   const { executor, longTasks, baseElement } = t.context;
 
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // Ensure the promise is resolved in the end.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
   t.is(longTasks.length, 1);
   t.false(executor.active);
   return longTasks[0];
@@ -116,22 +116,22 @@ test.serial('should create and release a long task', t => {
 test.serial('should nest long tasks', t => {
   const { executor, longTasks, baseElement } = t.context;
 
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // Nested: no new promise/task created.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // Unnest: the task is still active.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // Ensure the promise is resolved in the end.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
   t.is(longTasks.length, 1);
   t.false(executor.active);
   return longTasks[0];
@@ -141,22 +141,22 @@ test.serial('should restart a next long tasks', t => {
   const { executor, longTasks, baseElement } = t.context;
 
   // Start 1st task.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // End 1st task.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
   t.is(longTasks.length, 1);
   t.false(executor.active);
 
   // Start 2nd task.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
   t.is(longTasks.length, 2);
   t.true(executor.active);
 
   // End 2nd task.
-  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
   t.is(longTasks.length, 2);
   t.false(executor.active);
 

--- a/src/test/main-thread/object-creation.test.ts
+++ b/src/test/main-thread/object-creation.test.ts
@@ -115,6 +115,7 @@ test('Object creation with mutation at a zero offset', t => {
       ...serializedArgs,
     ]),
     0,
+    /* allow */ true,
   );
 
   t.true(stub.withArgs(1, 2, 3, 4).calledOnce);
@@ -162,7 +163,7 @@ test('Object creation with mutation at non-zero offset', t => {
 
   // add three values to the start of the mutation and change the offset
   const mutationsArray = new Uint16Array([1, 2, 3].concat(mutation));
-  objectCreationProcessor.execute(mutationsArray, 3);
+  objectCreationProcessor.execute(mutationsArray, 3, /* allow */ true);
 
   t.true(stub.withArgs(1, 2, 3, 4).calledOnce);
   t.is(objectContext.get(objectId), gradientObject);
@@ -204,7 +205,7 @@ test('Returns correct end offset', t => {
   ];
 
   const mutationsArray = new Uint16Array([1, 2, 3].concat(mutation));
-  const endOffset = objectCreationProcessor.execute(mutationsArray, 3);
+  const endOffset = objectCreationProcessor.execute(mutationsArray, 3, /* allow */ true);
 
   t.is(mutationsArray[endOffset], 32);
 });

--- a/src/test/main-thread/object-mutation.test.ts
+++ b/src/test/main-thread/object-mutation.test.ts
@@ -264,7 +264,7 @@ test('Mutation starts at a non-zero offset', t => {
 
   // add three values to the start of the mutation and change the offset
   const mutationsArray = new Uint16Array([1, 2, 3].concat(mutation));
-  objectMutationProcessor.execute(mutationsArray, 3);
+  objectMutationProcessor.execute(mutationsArray, 3, /* allow */ true);
 
   t.true(stub.withArgs(...args).calledOnce);
 });
@@ -304,7 +304,7 @@ test('Returns correct end offset', t => {
   ];
 
   const mutationsArray = new Uint16Array([1, 2, 3].concat(mutation));
-  const endOffset = objectMutationProcessor.execute(mutationsArray, 3);
+  const endOffset = objectMutationProcessor.execute(mutationsArray, 3, /* allow */ true);
 
   t.is(mutationsArray[endOffset], 32);
 });
@@ -328,6 +328,7 @@ function executeCall(
       ...serializedArgs,
     ]),
     0,
+    /* allow */ true,
   );
 }
 

--- a/src/test/main-thread/string-properties.test.ts
+++ b/src/test/main-thread/string-properties.test.ts
@@ -89,6 +89,7 @@ test('setting property to a new string', t => {
   propertyProcessor.execute(
     new Uint16Array([TransferrableMutationType.PROPERTIES, inputElement._index_, storedValueKey, NumericBoolean.FALSE, storedNewValue]),
     0,
+    /* allow */ true,
   );
   t.is(inputElement.value, newValue);
 });
@@ -104,12 +105,14 @@ test('setting property back to an empty string', t => {
   propertyProcessor.execute(
     new Uint16Array([TransferrableMutationType.PROPERTIES, inputElement._index_, storedValueKey, NumericBoolean.FALSE, storedFirstUpdateValue]),
     0,
+    /* allow */ true,
   );
   t.is(inputElement.value, firstUpdateValue);
 
   propertyProcessor.execute(
     new Uint16Array([TransferrableMutationType.PROPERTIES, inputElement._index_, storedValueKey, NumericBoolean.FALSE, storedSecondUpdateValue]),
     0,
+    /* allow */ true,
   );
   t.is(inputElement.value, secondUpdateValue);
 });

--- a/src/transfer/TransferrableMutation.ts
+++ b/src/transfer/TransferrableMutation.ts
@@ -30,6 +30,24 @@ export const enum TransferrableMutationType {
   STORAGE = 12,
 }
 
+/**
+ * Returns true if the mutation type can cause a user-visible change to the DOM.
+ * @param type
+ */
+export const isUserVisibleMutation = (type: TransferrableMutationType): boolean => {
+  switch (type) {
+    case TransferrableMutationType.EVENT_SUBSCRIPTION:
+    case TransferrableMutationType.GET_BOUNDING_CLIENT_RECT:
+    case TransferrableMutationType.LONG_TASK_START:
+    case TransferrableMutationType.LONG_TASK_END:
+    case TransferrableMutationType.STORAGE:
+    case TransferrableMutationType.OFFSCREEN_CANVAS_INSTANCE:
+      return false;
+    default:
+      return true;
+  }
+};
+
 export const DefaultAllowedMutations = [
   TransferrableMutationType.ATTRIBUTES,
   TransferrableMutationType.CHARACTER_DATA,


### PR DESCRIPTION
Enables enforcement user gesture constraints in use cases like `amp-script`.

Context: https://github.com/ampproject/amphtml/issues/26375