### PR TITLE
Document.getElementsByTagName() and Document.getElementsByClassName()…

### DIFF
--- a/web_compat_table.md
+++ b/web_compat_table.md
@@ -81,9 +81,9 @@ This section highlights the DOM APIs that are implemented in WorkerDOM currently
 | Document.fullscreenElement                          | ✖️     |                                                  | 
 | Document.getAnimations()                            | ✖️     |                                                  | 
 | document.getElementById(String id)                  | ✔️     |                                                  | 
-| Document.getElementsByClassName()                   | ✖️     |                                                  | 
+| Document.getElementsByClassName()                   | ✔️     |                                                  | 
 | document.getElementsByName()                        | ✖️     |                                                  | 
-| Document.getElementsByTagName()                     | ✖️     |                                                  | 
+| Document.getElementsByTagName()                     | ✔️     |                                                  | 
 | Document.getElementsByTagNameNS()                   | ✖️     |                                                  | 
 | document.hasFocus()                                 | ✖️     |                                                  | 
 | Document.hasStorageAccess()                         | ✖️     |                                                  | 


### PR DESCRIPTION
… actually work

See https://github.com/ampproject/worker-dom/issues/782. At least for me, both of these methods have worked!