### PR TITLE
Do not strictly check force values in DOMTokenList.toggle

### DIFF
--- a/src/test/domtokenlist/toggle.test.ts
+++ b/src/test/domtokenlist/toggle.test.ts
@@ -114,3 +114,19 @@ test('toggle a token with force=true value', (t) => {
   t.is(tokenList.toggle('foo', true), true);
   t.is(tokenList.value, 'foo foo bar bar');
 });
+
+test('toggle off token with falsey force value', (t) => {
+  const { tokenList } = t.context;
+
+  tokenList.value = 'foo foo bar';
+  t.is(tokenList.toggle('foo', ''), false);
+  t.is(tokenList.value, 'bar');
+});
+
+test('toggle on a token with truthy force value', (t) => {
+  const { tokenList } = t.context;
+
+  tokenList.value = 'foo foo bar';
+  t.is(tokenList.toggle('foo', []), true);
+  t.is(tokenList.value, 'foo foo bar');
+});

--- a/src/worker-thread/dom/DOMTokenList.ts
+++ b/src/worker-thread/dom/DOMTokenList.ts
@@ -170,19 +170,19 @@ export class DOMTokenList {
    * @param force changes toggle into a one way-only operation. true => token added. false => token removed.
    * @return true if the token is in the list following mutation, false if not.
    */
-  public toggle(token: string, force?: boolean): boolean {
+  public toggle(token: string, force?: any): boolean {
     if (WHITESPACE_REGEX.test(token)) {
       throw new TypeError('Uncaught DOMException');
     }
 
     if (!this[TransferrableKeys.tokens].includes(token)) {
-      if (force !== false) {
-        // Note, this will add the token if force is undefined (not passed into the method), or true.
+      if (force === undefined || !!force) {
+        // Note, this will add the token if force is undefined (not passed into the method), or truthy.
         this.add(token);
       }
       return true;
-    } else if (force !== true) {
-      // Note, this will remove the token if force is undefined (not passed into the method), or false.
+    } else if (!force) {
+      // Note, this will remove the token if force is undefined (not passed into the method), or falsey.
       this.remove(token);
       return false;
     }


### PR DESCRIPTION
fixes #831

[old spec discussion](https://github.com/whatwg/dom/issues/64)
relevant bits being gecko had a discrepancy (that is fixed in modern firefox), and IE ignores `force` all together, so this is never be good there either way