### PR TITLE
Do not use loose mode for ES5 transpilation

### DIFF
--- a/config/rollup.plugins.js
+++ b/config/rollup.plugins.js
@@ -38,7 +38,7 @@ export function babelPlugin({ transpileToES5, allowConsole = false, allowPostMes
         '@babel/env',
         {
           targets,
-          loose: true,
+          loose: !transpileToES5,
           modules: false,
           bugfixes: true,
         },

--- a/package.json
+++ b/package.json
@@ -89,16 +89,16 @@
       "./dist/**/*.mjs"
     ],
     "./dist/worker/worker.mjs": {
-      "brotli": "11.4 kB"
+      "brotli": "11.5 kB"
     },
     "./dist/worker/worker.js": {
-      "brotli": "12.6 kB"
+      "brotli": "13 kB"
     },
     "./dist/main.mjs": {
-      "brotli": "3.73 kB"
+      "brotli": "4 kB"
     },
     "./dist/main.js": {
-      "brotli": "4.1 kB"
+      "brotli": "5 kB"
     }
   },
   "esm": {


### PR DESCRIPTION
Using loose mode results in output that does not execute as expected.