### PR TITLE
worker-thread amp binary: add in missing compiler plugin

### DIFF
--- a/config/rollup.worker-thread.js
+++ b/config/rollup.worker-thread.js
@@ -107,6 +107,7 @@ const ESModules = [
         transpileToES5: false,
         allowConsole: true,
       }),
+      ...compilePlugins,
     ],
   },
   {


### PR DESCRIPTION
Should we be running the AMP version through terser? If so then I'll also add this to main-thread.

**before**: mjs was +17kb 
![before](https://user-images.githubusercontent.com/4656974/87979491-24d8fd80-caa0-11ea-8bc8-b793a0f84bb7.png)

**after**: mjs is -1.62kb
![after](https://user-images.githubusercontent.com/4656974/87979495-26a2c100-caa0-11ea-9938-2564708bface.png)

