### PR TITLE
add compilePlugins to dist/amp/worker/worker.nodom.mjs and dist/amp/worker/worker.mjs

### DIFF
--- a/config/rollup.worker-thread.js
+++ b/config/rollup.worker-thread.js
@@ -107,6 +107,7 @@ const ESModules = [
         transpileToES5: false,
         allowConsole: true,
       }),
+      ...compilePlugins,
     ],
   },
   {
@@ -156,6 +157,7 @@ const ESModules = [
         transpileToES5: false,
         allowConsole: true,
       }),
+      ...compilePlugins,
     ],
   },
   {


### PR DESCRIPTION
Since we distribute these files as the module version ideally they should be optimized from the get go instead of optimizing them on the user side (such as the AMP library)