### PR TITLE
decode numeric html entitites

### DIFF
--- a/src/test/element/innerHTML.test.ts
+++ b/src/test/element/innerHTML.test.ts
@@ -164,11 +164,11 @@ test('set text with numeric html entities', (t) => {
   node.innerHTML = '<p>&#xabc;</p>';
   t.is(node.innerHTML, '<p>઼</p>');
 
-  node.innerHTML = '<p>&#x1F4A9;</p>';
-  t.is(node.innerHTML, '<p>💩</p>');
+  node.innerHTML = '<p>&#x1F913;</p>';
+  t.is(node.innerHTML, '<p>🤓</p>');
 
-  node.innerHTML = '<p>&#X1F4A9;</p>';
-  t.is(node.innerHTML, '<p>💩</p>');
+  node.innerHTML = '&#X1F913;';
+  t.is(node.innerHTML, '🤓');
 });
 
 test('set closes tags by closing others', (t) => {

--- a/src/test/element/innerHTML.test.ts
+++ b/src/test/element/innerHTML.test.ts
@@ -166,6 +166,9 @@ test('set text with numeric html entities', (t) => {
 
   node.innerHTML = '<p>&#x1F4A9;</p>';
   t.is(node.innerHTML, '<p>💩</p>');
+
+  node.innerHTML = '<p>&#X1F4A9;</p>';
+  t.is(node.innerHTML, '<p>💩</p>');
 });
 
 test('set closes tags by closing others', (t) => {

--- a/src/test/element/innerHTML.test.ts
+++ b/src/test/element/innerHTML.test.ts
@@ -160,9 +160,12 @@ test('set text with numeric html entities', (t) => {
 
   node.innerHTML = '<p>&#x26;</p>';
   t.is(node.innerHTML, '<p>&</p>');
-  
+
   node.innerHTML = '<p>&#xabc;</p>';
   t.is(node.innerHTML, '<p>઼</p>');
+
+  node.innerHTML = '<p>&#x1F4A9;</p>';
+  t.is(node.innerHTML, '<p>💩</p>');
 });
 
 test('set closes tags by closing others', (t) => {

--- a/src/test/element/innerHTML.test.ts
+++ b/src/test/element/innerHTML.test.ts
@@ -152,6 +152,16 @@ test('set invalid html throws', (t) => {
   t.throws(() => (node.innerHTML = '<div>'));
 });
 
+test('set text with numeric html entities', (t) => {
+  const { node } = t.context;
+
+  node.innerHTML = '<p>&#38;</p>';
+  t.is(node.innerHTML, '<p>&</p>');
+
+  node.innerHTML = '<p>&#x26;</p>';
+  t.is(node.innerHTML, '<p>&</p>');
+});
+
 test('set closes tags by closing others', (t) => {
   const { node } = t.context;
   node.innerHTML = '<div><a></div>';

--- a/src/test/element/innerHTML.test.ts
+++ b/src/test/element/innerHTML.test.ts
@@ -160,6 +160,9 @@ test('set text with numeric html entities', (t) => {
 
   node.innerHTML = '<p>&#x26;</p>';
   t.is(node.innerHTML, '<p>&</p>');
+  
+  node.innerHTML = '<p>&#xabc;</p>';
+  t.is(node.innerHTML, '<p>઼</p>');
 });
 
 test('set closes tags by closing others', (t) => {

--- a/src/third_party/html-parser/README.md
+++ b/src/third_party/html-parser/README.md
@@ -9,3 +9,4 @@ Replaced model used to represent node elements for ours (/src/worker-thread/dom)
 Removed all class declarations for nodes previously used.
 Removed CSS Matcher class.
 Parsed HTML Comment nodes (previously ignored).
+Decode numeric entities in text nodes.

--- a/src/third_party/html-parser/html-parser.ts
+++ b/src/third_party/html-parser/html-parser.ts
@@ -2,6 +2,7 @@ import { Element } from '../../worker-thread/dom/Element';
 import { Node } from '../../worker-thread/dom/Node';
 import { SVG_NAMESPACE, HTML_NAMESPACE } from '../../transfer/TransferrableNodes';
 import { toLower, toUpper } from '../../utils';
+import { CharacterData } from '../../worker-thread/dom/CharacterData';
 
 interface Elements {
   [key: string]: boolean;
@@ -235,7 +236,7 @@ export function parse(data: string, rootElement: Element) {
 
 function decodeNumericEntities(html: string) {
   return html.replace(/&#(x?[\da-f]+);?/gi, function (s, entity) {
-    let code = entity.charAt(0) === 'x' ? parseInt(entity.substr(1).toLowerCase(), 16) : parseInt(entity, 10);
+    let code = entity.charAt(0).toLowerCase() === 'x' ? parseInt(entity.substr(1).toLowerCase(), 16) : parseInt(entity, 10);
 
     // 1114111 is the largest valid unicode codepoint.
     if (isNaN(code) || code > 1114111) {

--- a/src/third_party/html-parser/html-parser.ts
+++ b/src/third_party/html-parser/html-parser.ts
@@ -128,7 +128,7 @@ export function parse(data: string, rootElement: Element) {
     if (lastTextPos < match.index) {
       // if has content
       const text = data.slice(lastTextPos, match.index);
-      currentParent.appendChild(ownerDocument.createTextNode(text));
+      currentParent.appendChild(ownerDocument.createTextNode(decodeNumericEntities(text)));
     }
     lastTextPos = kMarkupPattern.lastIndex;
     if (commentContents !== undefined) {
@@ -231,4 +231,16 @@ export function parse(data: string, rootElement: Element) {
   }
 
   throw new Error('Attempting to parse invalid HTML.');
+}
+
+function decodeNumericEntities(html: string) {
+  return html.replace(/&#(x?\d+);?/g, function (s, entity) {
+    const code = entity.charAt(0) === 'x' ? parseInt(entity.substr(1).toLowerCase(), 16) : parseInt(entity, 10);
+
+    let chr;
+    if (!(isNaN(code) || code < -32768 || code > 65535)) {
+      chr = String.fromCharCode(code);
+    }
+    return chr || s;
+  });
 }

--- a/src/third_party/html-parser/html-parser.ts
+++ b/src/third_party/html-parser/html-parser.ts
@@ -234,11 +234,11 @@ export function parse(data: string, rootElement: Element) {
 }
 
 function decodeNumericEntities(html: string) {
-  return html.replace(/&#(x?\d+);?/g, function (s, entity) {
+  return html.replace(/&#(x?[\da-zA-Z]+);?/g, function (s, entity) {
     const code = entity.charAt(0) === 'x' ? parseInt(entity.substr(1).toLowerCase(), 16) : parseInt(entity, 10);
 
     let chr;
-    if (!(isNaN(code) || code < -32768 || code > 65535)) {
+    if (!(isNaN(code) || code < 0 || code > 65535)) {
       chr = String.fromCharCode(code);
     }
     return chr || s;

--- a/src/third_party/html-parser/html-parser.ts
+++ b/src/third_party/html-parser/html-parser.ts
@@ -2,7 +2,6 @@ import { Element } from '../../worker-thread/dom/Element';
 import { Node } from '../../worker-thread/dom/Node';
 import { SVG_NAMESPACE, HTML_NAMESPACE } from '../../transfer/TransferrableNodes';
 import { toLower, toUpper } from '../../utils';
-import { CharacterData } from '../../worker-thread/dom/CharacterData';
 
 interface Elements {
   [key: string]: boolean;

--- a/src/third_party/html-parser/html-parser.ts
+++ b/src/third_party/html-parser/html-parser.ts
@@ -234,7 +234,7 @@ export function parse(data: string, rootElement: Element) {
 }
 
 function decodeNumericEntities(html: string) {
-  return html.replace(/&#(x?[\da-fA-F]+);?/g, function (s, entity) {
+  return html.replace(/&#(x?[\da-f]+);?/gi, function (s, entity) {
     let code = entity.charAt(0) === 'x' ? parseInt(entity.substr(1).toLowerCase(), 16) : parseInt(entity, 10);
 
     // 1114111 is the largest valid unicode codepoint.

--- a/src/third_party/html-parser/html-parser.ts
+++ b/src/third_party/html-parser/html-parser.ts
@@ -234,13 +234,14 @@ export function parse(data: string, rootElement: Element) {
 }
 
 function decodeNumericEntities(html: string) {
-  return html.replace(/&#(x?[\da-zA-Z]+);?/g, function (s, entity) {
-    const code = entity.charAt(0) === 'x' ? parseInt(entity.substr(1).toLowerCase(), 16) : parseInt(entity, 10);
+  return html.replace(/&#(x?[\da-fA-F]+);?/g, function (s, entity) {
+    let code = entity.charAt(0) === 'x' ? parseInt(entity.substr(1).toLowerCase(), 16) : parseInt(entity, 10);
 
-    let chr;
-    if (!(isNaN(code) || code < 0 || code > 65535)) {
-      chr = String.fromCharCode(code);
+    // 1114111 is the largest valid unicode codepoint.
+    if (isNaN(code) || code > 1114111) {
+      return s;
     }
-    return chr || s;
+
+    return String.fromCodePoint(code) || s;
   });
 }


### PR DESCRIPTION
Addressed the easy half of https://github.com/ampproject/worker-dom/issues/613

cc @caroqliu.

Note that we can get a really big bang for the innerHTML buck if we also decide to decode just the 4 required bits for [html encoding](https://developer.mozilla.org/en-US/docs/Glossary/Entity) (`<` `>`, `&`, `"`). Could be worth doing in addition to all numeric.