### PR TITLE
implement setInnerHTMLAsync

### DIFF
--- a/demo/entity-decoding/entity-decoding.js
+++ b/demo/entity-decoding/entity-decoding.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const btn = document.getElementsByTagName('button')[0];
+
+btn.addEventListener('click', async () => {
+  const emojiEntities = ['😀', '😃', '😄', '😁', '😆', '😅', '🤣', '😂'].map((emoji) => {
+    return `&#${emoji.codePointAt(0)};`;
+  });
+
+  const h1 = document.createElement('h1');
+  const randomEmojiEntity = emojiEntities[Math.floor(Math.random() * emojiEntities.length)];
+  // Works for disconnected elements as well as already-connected ones.
+  document.body.appendChild(h1);
+  await h1.setInnerHTMLAsync(`Random emoji is: ${randomEmojiEntity}`);
+  console.error(h1.innerHTML);
+});
+
+requestAnimationFrame(() => console.log('animation'));

--- a/demo/entity-decoding/index.html
+++ b/demo/entity-decoding/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Hello World</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="/demo.css" rel="stylesheet">
+  <script src="/dist/main.mjs" type="module"></script>
+  <script src="/dist/main.js" nomodule defer></script>
+</head>
+<body>
+  <div src="entity-decoding.js" id="upgrade-me">
+    <div class="root">
+      <button>Insert Random Emoji</button>
+    </div>
+  </div>
+  <script type="module">
+    import {upgradeElement} from '/dist/main.mjs';
+    upgradeElement(document.getElementById('upgrade-me'), '/dist/worker/worker.mjs');
+  </script>
+  <script nomodule async=false defer>
+    document.addEventListener('DOMContentLoaded', function() {
+      MainThread.upgradeElement(document.getElementById('upgrade-me'), '/dist/worker/worker.js');
+    }, false);
+  </script>
+</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,6 +13,7 @@
   <h3>Basic</h3>
   <ul>
     <li><a href='empty/'>Hello Empty World</a></li>
+    <li><a href='entity-decoding/'>Entity decoding</a></li>
     <li><a href='hello-world/'>Hello World</a></li>
     <li><a href='two-roots/'>Two Roots</a></li>
     <li><a href='clone-node/'>Clone Node</a></li>

--- a/src/main-thread/commands/set-inner-html.ts
+++ b/src/main-thread/commands/set-inner-html.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TransferrableKeys } from '../../transfer/TransferrableKeys';
+import { MessageType } from '../../transfer/Messages';
+import { CommandExecutorInterface } from './interface';
+import { TransferrableMutationType, SetInnerHTMLMutationIndex } from '../../transfer/TransferrableMutation';
+import { createHydrateableRootNode } from '../serialize';
+
+export const SetInnerHTMLProcessor: CommandExecutorInterface = (stringContext, nodes, workerContext, objectContext, config) => {
+  const allowedExecution = config.executorsAllowed.includes(TransferrableMutationType.SET_INNER_HTML);
+
+  return {
+    execute(mutations: Uint16Array, startPosition: number, allowedMutation: boolean): number {
+      if (allowedExecution && allowedMutation) {
+        const targetIndex = mutations[startPosition + SetInnerHTMLMutationIndex.Target];
+        const html = stringContext.get(mutations[startPosition + SetInnerHTMLMutationIndex.Value]);
+        let target = nodes.getNode(targetIndex);
+        if (!target) {
+          target = document.createElement('div'); //  Disconnected node, just for calculating innerHTML.
+        }
+        target.innerHTML = html;
+
+        const { skeleton, strings } = createHydrateableRootNode(target, config, workerContext);
+        workerContext.messageToWorker({
+          [TransferrableKeys.type]: MessageType.HYDRATE,
+          [TransferrableKeys.target]: [targetIndex],
+          [TransferrableKeys.nodes]: skeleton,
+          [TransferrableKeys.strings]: strings,
+        });
+      }
+
+      return startPosition + SetInnerHTMLMutationIndex.End;
+    },
+    print(mutations: Uint16Array, startPosition: number): {} {
+      const targetIndex = mutations[startPosition + SetInnerHTMLMutationIndex.Target];
+      const html = mutations[startPosition + SetInnerHTMLMutationIndex.Value];
+      const target = nodes.getNode(targetIndex);
+      return {
+        type: 'SET_INNER_HTML',
+        target,
+        html,
+        allowedExecution,
+      };
+    },
+  };
+};

--- a/src/main-thread/mutator.ts
+++ b/src/main-thread/mutator.ts
@@ -35,6 +35,7 @@ import { ObjectContext } from './object-context';
 import { ImageBitmapProcessor } from './commands/image-bitmap';
 import { StorageProcessor } from './commands/storage';
 import { FunctionProcessor } from './commands/function';
+import { SetInnerHTMLProcessor } from './commands/set-inner-html';
 
 export class MutatorProcessor {
   private stringContext: StringContext;
@@ -88,6 +89,7 @@ export class MutatorProcessor {
       [TransferrableMutationType.IMAGE_BITMAP_INSTANCE]: ImageBitmapProcessor.apply(null, args),
       [TransferrableMutationType.STORAGE]: StorageProcessor.apply(null, args),
       [TransferrableMutationType.FUNCTION_CALL]: FunctionProcessor.apply(null, args),
+      [TransferrableMutationType.SET_INNER_HTML]: SetInnerHTMLProcessor.apply(null, args),
     };
   }
 

--- a/src/transfer/Messages.ts
+++ b/src/transfer/Messages.ts
@@ -36,6 +36,7 @@ export const enum MessageType {
   IMAGE_BITMAP_INSTANCE = 10,
   GET_STORAGE = 11,
   FUNCTION = 12,
+  SET_INNER_HTML = 13,
   // NAVIGATION_PUSH_STATE = 8,
   // NAVIGATION_REPLACE_STATE = 9,
   // NAVIGATION_POP_STATE = 10,
@@ -54,6 +55,7 @@ export type MessageFromWorker = {
 
 export interface HydrationToWorker {
   readonly [TransferrableKeys.type]: MessageType.HYDRATE;
+  readonly [TransferrableKeys.target]: TransferredNode;
   readonly [TransferrableKeys.strings]: Array<string>;
   readonly [TransferrableKeys.nodes]: HydrateableNode;
 }
@@ -106,7 +108,8 @@ export type MessageToWorker =
   | OffscreenCanvasToWorker
   | ImageBitmapToWorker
   | StorageValueToWorker
-  | FunctionCallToWorker;
+  | FunctionCallToWorker
+  | HydrationToWorker;
 
 /**
  * Can parameterize a method invocation message as a getter or setter.

--- a/src/transfer/TransferrableMutation.ts
+++ b/src/transfer/TransferrableMutation.ts
@@ -29,6 +29,7 @@ export const enum TransferrableMutationType {
   IMAGE_BITMAP_INSTANCE = 11,
   STORAGE = 12,
   FUNCTION_CALL = 13,
+  SET_INNER_HTML = 14,
 }
 
 /**
@@ -44,6 +45,7 @@ export const isUserVisibleMutation = (type: TransferrableMutationType): boolean 
     case TransferrableMutationType.STORAGE:
     case TransferrableMutationType.OFFSCREEN_CANVAS_INSTANCE:
     case TransferrableMutationType.FUNCTION_CALL:
+    case TransferrableMutationType.SET_INNER_HTML:
       return false;
     default:
       return true;
@@ -65,6 +67,7 @@ export const DefaultAllowedMutations = [
   TransferrableMutationType.IMAGE_BITMAP_INSTANCE,
   TransferrableMutationType.STORAGE,
   TransferrableMutationType.FUNCTION_CALL,
+  TransferrableMutationType.SET_INNER_HTML,
 ];
 
 export const ReadableMutationType: { [key: number]: string } = {
@@ -82,6 +85,7 @@ export const ReadableMutationType: { [key: number]: string } = {
   11: 'IMAGE_BITMAP_INSTANCE',
   12: 'STORAGE',
   13: 'FUNCTION_INVOCATION',
+  14: 'SET_INNER_HTML',
 };
 
 /**
@@ -270,4 +274,17 @@ export const enum FunctionMutationIndex {
   Index = 2,
   Value = 3,
   End = 4,
+}
+
+/**
+ * [
+ *   TransferrableMutationType.SET_INNER_HTML,
+ *   Target.index,
+ *   string (html)
+ * ]
+ */
+export const enum SetInnerHTMLMutationIndex {
+  Target = 1,
+  Value = 2,
+  End = 3,
 }


### PR DESCRIPTION
**summary**

Creates a new function on `Element` called `setInnerHTMLAsync(htmlStr)`. It functions exactly like `innerHTML = htmlStr` would on the main thread. This is because the implementation passes the string directly along to the main thread which actually sets innerHTML, and then the vdom is rehydrated. 