### PR TITLE
Configure renovate-bot to automerge PRs that have passing tests.

### DIFF
--- a/demo/preact-map/renovate.json
+++ b/demo/preact-map/renovate.json
@@ -1,4 +1,5 @@
 {
+  "automerge": true,
   "extends": [
     "config:base"
   ],

--- a/demo/react-map/renovate.json
+++ b/demo/react-map/renovate.json
@@ -1,4 +1,5 @@
 {
+  "automerge": true,
   "extends": [
     "config:base"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "automerge": true,
   "extends": [
     "config:base"
   ]


### PR DESCRIPTION
**Summary**
There are numerous steps we can take for [noise reduction](https://docs.renovatebot.com/noise-reduction/) of Renovate. This PR enables one of the basic ones, _automerging_. 

Potential future change: `automergeType=branch`, which would enable the bot to auto-push to master without creating a PR first in case of a branch with passing tests. It would only create a PR (and therefore notification) in case of failures.