### PR TITLE
Fix race between long task start and end handlers.

### DIFF
--- a/src/main-thread/commands/long-task.ts
+++ b/src/main-thread/commands/long-task.ts
@@ -53,6 +53,12 @@ export const LongTaskExecutor: LongTaskCommandExecutorInterface = (
           index++;
           if (!currentResolver) {
             const newResolver = new Promise((resolve) => (currentResolver = resolve));
+            // One of the worker-dom contracts is that there should not be two
+            // LONG_TASK_STARTs in a row without an END in between. In case both exist within
+            // the same set of mutations, a naive consumer will likely have a race since START is invoked
+            // synchronously via callback, whereas END must be chained to a resolving promise and therefore
+            // would occur afterwards.
+            // We guard against this by yielding to the event loop before calling longTask.
             setTimeout(() => {
               config.longTask?.(newResolver);
             }, 0);

--- a/src/main-thread/commands/long-task.ts
+++ b/src/main-thread/commands/long-task.ts
@@ -58,7 +58,7 @@ export const LongTaskExecutor: LongTaskCommandExecutorInterface = (
             // the same set of mutations, we need to guard against having a consumers 1st END
             // handler occur after the START handler. If we synchronously called longTask() here it
             // would likely occur due to scheduling of callbacks vs. promise.
-            // See: PR#.
+            // See: worker-dom/pull/989/files
             Promise.resolve().then(() => {
               if (config.longTask) {
                 config.longTask(newResolver);

--- a/src/main-thread/commands/long-task.ts
+++ b/src/main-thread/commands/long-task.ts
@@ -58,12 +58,8 @@ export const LongTaskExecutor: LongTaskCommandExecutorInterface = (
             // the same set of mutations, we need to guard against having a consumers 1st END
             // handler occur after the START handler. If we synchronously called longTask() here it
             // would likely occur due to scheduling of callbacks vs. promise.
-            // See: worker-dom/pull/989/files
-            Promise.resolve().then(() => {
-              if (config.longTask) {
-                config.longTask(newResolver);
-              }
-            });
+            // See: worker-dom/pull/989.
+            Promise.resolve().then(() => config.longTask && config.longTask(newResolver));
           }
         } else if (mutations[startPosition] === TransferrableMutationType.LONG_TASK_END) {
           index--;

--- a/src/main-thread/commands/long-task.ts
+++ b/src/main-thread/commands/long-task.ts
@@ -52,7 +52,10 @@ export const LongTaskExecutor: LongTaskCommandExecutorInterface = (
         if (mutations[startPosition] === TransferrableMutationType.LONG_TASK_START) {
           index++;
           if (!currentResolver) {
-            config.longTask(new Promise((resolve) => (currentResolver = resolve)));
+            const newResolver = new Promise((resolve) => (currentResolver = resolve));
+            setTimeout(() => {
+              config.longTask?.(newResolver);
+            }, 0);
           }
         } else if (mutations[startPosition] === TransferrableMutationType.LONG_TASK_END) {
           index--;

--- a/src/test/main-thread/long-task.test.ts
+++ b/src/test/main-thread/long-task.test.ts
@@ -24,7 +24,7 @@ import { WorkerContext } from '../../main-thread/worker';
 import { normalizeConfiguration, WorkerDOMConfiguration } from '../../main-thread/configuration';
 import { ObjectContext } from '../../main-thread/object-context';
 
-async function sleep(ms: number) {
+async function sleep(ms: number): Promise<void> {
   return new Promise((res) => setTimeout(res, ms));
 }
 
@@ -159,7 +159,7 @@ test.serial('multiple long tasks should have their handlers fired in sequence ST
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
   await sleep(0);
 
-  // End 1st task and start the second in the same task.
+  // End 1st task and start the second without a sleep in between.
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
   await sleep(0);

--- a/src/test/main-thread/long-task.test.ts
+++ b/src/test/main-thread/long-task.test.ts
@@ -21,8 +21,12 @@ import { TransferrableMutationType } from '../../transfer/TransferrableMutation'
 import { StringContext } from '../../main-thread/strings';
 import { NodeContext } from '../../main-thread/nodes';
 import { WorkerContext } from '../../main-thread/worker';
-import { normalizeConfiguration } from '../../main-thread/configuration';
+import { normalizeConfiguration, WorkerDOMConfiguration } from '../../main-thread/configuration';
 import { ObjectContext } from '../../main-thread/object-context';
+
+async function sleep(ms: number) {
+  return new Promise((res) => setTimeout(res, ms));
+}
 
 const test = anyTest as TestInterface<{
   env: Env;
@@ -33,6 +37,7 @@ const test = anyTest as TestInterface<{
   workerContext: WorkerContext;
   objectContext: ObjectContext;
   baseElement: HTMLElement;
+  config: WorkerDOMConfiguration;
 }>;
 
 test.beforeEach((t) => {
@@ -47,19 +52,14 @@ test.beforeEach((t) => {
     getWorker() {},
     messageToWorker() {},
   } as unknown) as WorkerContext;
-  const executor = LongTaskExecutor(
-    stringContext,
-    nodeContext,
-    workerContext,
-    objectContext,
-    normalizeConfiguration({
-      authorURL: 'authorURL',
-      domURL: 'domURL',
-      longTask: (promise: Promise<any>) => {
-        longTasks.push(promise);
-      },
-    }),
-  );
+  const config: WorkerDOMConfiguration = normalizeConfiguration({
+    authorURL: 'authorURL',
+    domURL: 'domURL',
+    longTask: (promise: Promise<any>) => {
+      longTasks.push(promise);
+    },
+  });
+  const executor = LongTaskExecutor(stringContext, nodeContext, workerContext, objectContext, config);
 
   baseElement._index_ = 1;
   document.body.appendChild(baseElement);
@@ -73,6 +73,7 @@ test.beforeEach((t) => {
     nodeContext,
     objectContext,
     workerContext,
+    config,
   };
 });
 
@@ -81,7 +82,7 @@ test.afterEach((t) => {
   env.dispose();
 });
 
-test.serial('should tolerate no callback', (t) => {
+test.serial('should tolerate no callback', async (t) => {
   const { longTasks, baseElement, stringContext, nodeContext, workerContext, objectContext } = t.context;
   const executor = LongTaskExecutor(
     stringContext,
@@ -96,67 +97,100 @@ test.serial('should tolerate no callback', (t) => {
 
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
+
+  await sleep(0);
   t.is(longTasks.length, 0);
 });
 
-test.serial('should create and release a long task', (t) => {
+test.serial('should create and release a long task', async (t) => {
   const { executor, longTasks, baseElement } = t.context;
 
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
+  await sleep(0);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // Ensure the promise is resolved in the end.
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
+  await sleep(0);
   t.is(longTasks.length, 1);
   t.false(executor.active);
+
   return longTasks[0];
 });
 
-test.serial('should nest long tasks', (t) => {
+test.serial('should nest long tasks', async (t) => {
   const { executor, longTasks, baseElement } = t.context;
 
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
+  await sleep(0);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // Nested: no new promise/task created.
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
+  await sleep(0);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // Unnest: the task is still active.
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
+  await sleep(0);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // Ensure the promise is resolved in the end.
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
+  await sleep(0);
   t.is(longTasks.length, 1);
   t.false(executor.active);
   return longTasks[0];
 });
 
-test.serial('should restart a next long tasks', (t) => {
+test.serial('multiple long tasks should have their handlers fired in sequence START,END,START', async (t) => {
+  const { executor, baseElement, config } = t.context;
+  let handlerCallSequence: Array<'start' | 'end'> = [];
+  config.longTask = (p) => {
+    handlerCallSequence.push('start');
+    p.then(() => handlerCallSequence.push('end'));
+  };
+
+  // Start 1st task.
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
+  await sleep(0);
+
+  // End 1st task and start the second in the same task.
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
+  executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
+  await sleep(0);
+
+  t.deepEqual(handlerCallSequence, ['start', 'end', 'start']);
+});
+
+test.serial('should restart a next long tasks', async (t) => {
   const { executor, longTasks, baseElement } = t.context;
 
   // Start 1st task.
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
+  await sleep(0);
   t.is(longTasks.length, 1);
   t.true(executor.active);
 
   // End 1st task.
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
+  await sleep(0);
   t.is(longTasks.length, 1);
   t.false(executor.active);
 
   // Start 2nd task.
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_START, baseElement._index_]), 0, /* allow */ true);
+  await sleep(0);
   t.is(longTasks.length, 2);
   t.true(executor.active);
 
   // End 2nd task.
   executor.execute(new Uint16Array([TransferrableMutationType.LONG_TASK_END, baseElement._index_]), 0, /* allow */ true);
+  await sleep(0);
   t.is(longTasks.length, 2);
   t.false(executor.active);
 


### PR DESCRIPTION
**problem**
Consumers of `worker-dom` using the `longTask` API are notified of a new long task via callback and are notified of a long task end via Promise. In general this is fine.

There are situation in which both of these events occur within the same task. This is particularly true when the page is inactive and therefore `postMessage` processing is delayed until the page has been returned to.

A naive consumer will then run into the strange situation where they are notified of a 2nd long task start before receiving the 1st end. For `<amp-script>` this meant a sequence of events like this:

1. Long task start
2. Long task start
3. Long task end  (now `inLongTask=false`)
4. `<amp-script>` mutation pump receives mutations but inLongTask=false and activation time was set by (3), and therefore it panics.

**solution notes**
Initially I had solved this in `<amp-script>` via counter, but that felt wasteful. Instead I think its more elegant to sequence the `config.longTask` call after a `Promise.resolve()`, which would be guaranteed to run after the consumers `.then()`.

Note that all of the pre-existing tests I've modified would have passed with the added `await sleep(0)`s  even before this PR, whereas the newly introduced test would have failed.

Fixes: https://github.com/ampproject/amphtml/issues/30548