### PR TITLE
renovate-bot: only once a week, and all package

### DIFF
--- a/demo/preact-map/renovate.json
+++ b/demo/preact-map/renovate.json
@@ -1,12 +1,14 @@
 {
   "automerge": true,
   "extends": [
-    "config:base"
+    "config:base",
+    "schedule:earlyMondays"
   ],
   "dependencies": {
     "enabled": false
   },
   "devDependencies": {
     "enabled": false
-  }
+  },
+  "groupName": "all"
 }

--- a/demo/react-map/renovate.json
+++ b/demo/react-map/renovate.json
@@ -1,12 +1,14 @@
 {
   "automerge": true,
   "extends": [
-    "config:base"
+    "config:base",
+    "schedule:earlyMondays"
   ],
   "dependencies": {
     "enabled": false
   },
   "devDependencies": {
     "enabled": false
-  }
+  },
+  "groupName": "all"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "automerge": true,
   "extends": [
-    "config:base"
-  ]
+    "config:base",
+    "schedule:earlyMondays"
+  ],
+  "groupName": "all"
 }


### PR DESCRIPTION
**summary**
Makes two changes to the renovate config, both intended to reduce noise.
1. Group all package upgrades together.
2. Schedule the PR to be created once per week, instead of at all hours.

Note: there is a separate request I filed to install `renovate-approve-bot` for auto-approving PRs. They'll still be blocked by passing tests. All of these changes combined should significantly reduce our maintenance burden.