### PR TITLE
storage should throw if unsupported

### DIFF
--- a/demo/iframe/iframe.html
+++ b/demo/iframe/iframe.html
@@ -5,6 +5,22 @@
   <body>
     <div src="storage.js" id="upgrade-me"></div>
     <script type="module">
+      // Force storage access to throw, to simulate crossorigin incognito mode behavior.
+      delete window.localStorage;
+      Object.defineProperty(window, 'localStorage', {
+        enumerable: true,
+        get: () => {
+          throw new Error('Access denied');
+        },
+      }); 
+      delete window.sessionStorage; 
+      Object.defineProperty(window, 'sessionStorage', {
+        enumerable: true,
+        get: () => {
+          throw new Error('Access denied');
+        },
+      }); 
+      
       import { upgradeElement } from '/dist/amp-debug/main.mjs';
       upgradeElement(document.getElementById('upgrade-me'), '/dist/amp-debug/worker/worker.mjs');
     </script>

--- a/demo/iframe/iframe.html
+++ b/demo/iframe/iframe.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <script src="/dist/amp-debug/main.mjs" type="module"></script> 
+  </head>
+  <body>
+    <div src="storage.js" id="upgrade-me"></div>
+    <script type="module">
+      import { upgradeElement } from '/dist/amp-debug/main.mjs';
+      upgradeElement(document.getElementById('upgrade-me'), '/dist/amp-debug/worker/worker.mjs');
+    </script>
+  </body>
+</html>

--- a/demo/iframe/index.html
+++ b/demo/iframe/index.html
@@ -1,11 +1,12 @@
-<!-- 
-  This file added to assist in testing WorkerDOM iframed use cases. 
+<!--
+  This file added to assist in testing WorkerDOM iframed use cases.
   Notably, AMP Documents are often displayed in an crossorigin iframe.
   These documents have various restrictions, including no access to storage from
   within incognito windows.
 
-  In order to run this demo, you need to map workerdom.localhost to 
-  127.0.0.1 in your /etc/hosts file.
+  To run this demo:
+    - you need to map workerdom.localhost to 127.0.0.1 in your /etc/hosts file.
+    - load this page in both regular and incognito modes.
  -->
 <html>
   <head></head>

--- a/demo/iframe/index.html
+++ b/demo/iframe/index.html
@@ -1,0 +1,6 @@
+<html>
+  <head></head>
+  <body>
+    <iframe src="http://workerdom.localhost:3001/demo/iframe/iframe.html"></iframe>
+  </body>
+</html>

--- a/demo/iframe/index.html
+++ b/demo/iframe/index.html
@@ -1,3 +1,12 @@
+<!-- 
+  This file added to assist in testing WorkerDOM iframed use cases. 
+  Notably, AMP Documents are often displayed in an crossorigin iframe.
+  These documents have various restrictions, including no access to storage from
+  within incognito windows.
+
+  In order to run this demo, you need to map workerdom.localhost to 
+  127.0.0.1 in your /etc/hosts file.
+ -->
 <html>
   <head></head>
   <body>

--- a/demo/iframe/index.html
+++ b/demo/iframe/index.html
@@ -11,6 +11,6 @@
 <html>
   <head></head>
   <body>
-    <iframe src="http://workerdom.localhost:3001/demo/iframe/iframe.html"></iframe>
+    <iframe src="http://localhost:3001/demo/iframe/iframe.html"></iframe>
   </body>
 </html>

--- a/demo/iframe/storage.js
+++ b/demo/iframe/storage.js
@@ -1,0 +1,12 @@
+try {
+  localStorage.setItem('marco', 'polo');
+  console.log('localStorage is available');
+} catch (e) {
+  console.error(e);
+}
+try {
+  sessionStorage.setItem('marco', 'polo');
+  console.log('sessionStorage is available');
+} catch (e) {
+  console.error(e);
+}

--- a/demo/iframe/storage.js
+++ b/demo/iframe/storage.js
@@ -1,12 +1,14 @@
 try {
   localStorage.setItem('marco', 'polo');
-  console.log('localStorage is available');
+  console.log('localStorage is available at: ' + window.location);
 } catch (e) {
   console.error(e);
 }
 try {
   sessionStorage.setItem('marco', 'polo');
-  console.log('sessionStorage is available');
+  console.log('sessionStorage is available at: ' + window.location);
 } catch (e) {
   console.error(e);
 }
+
+console.log('Can run code after the storage access occurs');

--- a/demo/index.html
+++ b/demo/index.html
@@ -24,6 +24,7 @@
     <li><a href='webassembly/'>WebAssembly</a></li>
     <li><a href='default-input-listener/'>Default Input Listener</a></li>
     <li><a href='call-function/'>Call Function</a></li>
+    <li><a href='iframe/'>Iframed storage</a></li>
   </ul>
 
   <h3>Frameworks</h3>

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
       "brotli": "5 kB"
     },
     "./dist/worker/worker.mjs": {
-      "brotli": "11.85 kB"
+      "brotli": "12 kB"
     },
     "./dist/worker/worker.js": {
       "brotli": "13.5 kB"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
       "brotli": "5 kB"
     },
     "./dist/worker/worker.mjs": {
-      "brotli": "11.76 kB"
+      "brotli": "11.85 kB"
     },
     "./dist/worker/worker.js": {
       "brotli": "13.5 kB"

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -83,7 +83,14 @@ export class WorkerContext {
           ${JSON.stringify(sessionStorageSupportedStatus.errorMsg ?? sessionStorageData)}
         );
         workerDOM.document[${TransferrableKeys.observe}](this);
-        Object.keys(workerDOM).forEach(function(k){try{self[k]=workerDOM[k]}catch(e){}});
+        Object.keys(workerDOM).forEach(function(k){
+          /* These two are already assigned to Window. They also have the potential to throw
+           when accessed. */
+          if (k == 'localStorage' || k == 'sessionStorage') {
+            return;
+          }
+          self[k]=workerDOM[k]
+        });
       }).call(self);
       ${authorScript}
       //# sourceURL=${encodeURI(config.authorURL)}`;

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -24,7 +24,7 @@ import { StorageLocation } from '../transfer/TransferrableStorage';
 
 // TODO: Sanitizer storage init is likely broken, since the code currently
 // attempts to stringify a Promise.
-export type StorageInit = { storage: Storage | Promise<StorageValue> } | { errorMsg: string };
+export type StorageInit = { storage: Storage | Promise<StorageValue>; errorMsg: null } | { storage: null; errorMsg: string };
 export class WorkerContext {
   private [TransferrableKeys.worker]: Worker;
   private nodeContext: NodeContext;
@@ -113,12 +113,13 @@ export class WorkerContext {
 function getStorageInit(type: 'localStorage' | 'sessionStorage', sanitizer?: Sanitizer): StorageInit {
   try {
     if (!sanitizer) {
-      return { storage: window[type] };
+      return { storage: window[type], errorMsg: null };
     }
     return {
       storage: sanitizer.getStorage(type == 'localStorage' ? StorageLocation.Local : StorageLocation.Session),
+      errorMsg: null,
     };
   } catch (err) {
-    return { errorMsg: err.message };
+    return { errorMsg: err.message, storage: null };
   }
 }

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -76,9 +76,7 @@ export class WorkerContext {
           ${JSON.stringify(sessionStorageInit)}
         );
         workerDOM.document[${TransferrableKeys.observe}](this);
-        Object.keys(workerDOM).forEach(function(k){
-          k != 'localStorage' && k != 'sessionStorage' && (self[k]=workerDOM[k])
-        });
+        Object.keys(workerDOM).forEach(function(k){self[k]=workerDOM[k]});
       }).call(self);
       ${authorScript}
       //# sourceURL=${encodeURI(config.authorURL)}`;

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -24,7 +24,7 @@ import { StorageLocation } from '../transfer/TransferrableStorage';
 
 // TODO: Sanitizer storage init is likely broken, since the code currently
 // attempts to stringify a Promise.
-export type StorageInit = { supported: true; storage: Storage | Promise<StorageValue> } | { supported: false; errorMsg: string };
+export type StorageInit = { storage: Storage | Promise<StorageValue> } | { errorMsg: string };
 export class WorkerContext {
   private [TransferrableKeys.worker]: Worker;
   private nodeContext: NodeContext;
@@ -112,15 +112,13 @@ export class WorkerContext {
 
 function getStorageInit(type: 'localStorage' | 'sessionStorage', sanitizer?: Sanitizer): StorageInit {
   try {
-    let storage = window[type];
-    if (sanitizer) {
-      return {
-        supported: true,
-        storage: sanitizer.getStorage(type == 'localStorage' ? StorageLocation.Local : StorageLocation.Session),
-      };
+    if (!sanitizer) {
+      return { storage: window[type] };
     }
-    return { supported: true, storage };
+    return {
+      storage: sanitizer.getStorage(type == 'localStorage' ? StorageLocation.Local : StorageLocation.Session),
+    };
   } catch (err) {
-    return { supported: false, errorMsg: err.message };
+    return { errorMsg: err.message };
   }
 }

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -57,6 +57,8 @@ export class WorkerContext {
       }
     }
 
+    // We skip assigning the globals for localStorage and sessionStorage because
+    // We've already installed them. Also, accessing them can throw in incognito mode.
     const code = `
       'use strict';
       (function(){
@@ -75,12 +77,7 @@ export class WorkerContext {
         );
         workerDOM.document[${TransferrableKeys.observe}](this);
         Object.keys(workerDOM).forEach(function(k){
-          /* These two are already assigned to Window. They also have the potential to throw
-           when accessed. */
-          if (k == 'localStorage' || k == 'sessionStorage') {
-            return;
-          }
-          self[k]=workerDOM[k]
+          k != 'localStorage' && k != 'sessionStorage' && (self[k]=workerDOM[k])
         });
       }).call(self);
       ${authorScript}

--- a/src/test/main-thread/initialize-storage.test.ts
+++ b/src/test/main-thread/initialize-storage.test.ts
@@ -32,7 +32,6 @@ test.beforeEach((t) => {
 
 test.serial('Should install throwing storage', (t) => {
   const unsupportedAccess: WorkerStorageInit = {
-    supported: false,
     errorMsg: 'Access denied',
   };
   const { doc, self } = t.context;
@@ -45,7 +44,6 @@ test.serial('Should install throwing storage', (t) => {
 
 test.serial('Should install accessible storage', (t) => {
   const supportedAccess: WorkerStorageInit = {
-    supported: true,
     storage: {},
   };
   const { doc } = t.context;

--- a/src/test/main-thread/initialize-storage.test.ts
+++ b/src/test/main-thread/initialize-storage.test.ts
@@ -37,14 +37,10 @@ test.serial('Should install throwing storage', (t) => {
   };
   const { doc, self } = t.context;
   initialize(doc, [], {} as HydrateableNode, [], [], [0, 0], unsupportedAccess, unsupportedAccess);
-  t.throws(() => doc.defaultView.localStorage, {
-    message: unsupportedAccess.errorMsg,
-  });
-  t.throws(() => self.localStorage, { message: unsupportedAccess.errorMsg });
-  t.throws(() => doc.defaultView.sessionStorage, {
-    message: unsupportedAccess.errorMsg,
-  });
-  t.throws(() => self.sessionStorage, { message: unsupportedAccess.errorMsg });
+  t.falsy(doc.defaultView.localStorage);
+  t.falsy(doc.defaultView.sessionStorage);
+  t.falsy(self.localStorage);
+  t.falsy(self.sessionStorage);
 });
 
 test.serial('Should install accessible storage', (t) => {
@@ -54,11 +50,6 @@ test.serial('Should install accessible storage', (t) => {
   };
   const { doc } = t.context;
   initialize(doc, [], {} as HydrateableNode, [], [], [0, 0], supportedAccess, supportedAccess);
-  try {
-    doc.defaultView.localStorage;
-    doc.defaultView.sessionStorage;
-    t.pass('Accessing storage did not throw.');
-  } catch (err) {
-    t.fail(err);
-  }
+  t.truthy(doc.defaultView.localStorage);
+  t.truthy(doc.defaultView.sessionStorage);
 });

--- a/src/test/main-thread/initialize-storage.test.ts
+++ b/src/test/main-thread/initialize-storage.test.ts
@@ -32,6 +32,7 @@ test.beforeEach((t) => {
 
 test.serial('Should install throwing storage', (t) => {
   const unsupportedAccess: WorkerStorageInit = {
+    storage: null,
     errorMsg: 'Access denied',
   };
   const { doc, self } = t.context;
@@ -45,6 +46,7 @@ test.serial('Should install throwing storage', (t) => {
 test.serial('Should install accessible storage', (t) => {
   const supportedAccess: WorkerStorageInit = {
     storage: {},
+    errorMsg: null,
   };
   const { doc } = t.context;
   initialize(doc, [], {} as HydrateableNode, [], [], [0, 0], supportedAccess, supportedAccess);

--- a/src/test/main-thread/initialize-storage.test.ts
+++ b/src/test/main-thread/initialize-storage.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import anyTest, { TestInterface } from 'ava';
+import { initialize, WorkerStorageInit } from '../../worker-thread/initialize';
+import { Document } from '../../worker-thread/dom/Document';
+import { HydrateableNode } from '../../transfer/TransferrableNodes';
+
+const test = anyTest as TestInterface<{
+  doc: Document;
+  self: any;
+}>;
+test.beforeEach((t) => {
+  const doc = { defaultView: {} } as Document;
+  const self: any = {};
+  (globalThis as any).self = self;
+  t.context = { doc, self };
+});
+
+test.serial('Should install throwing storage', (t) => {
+  const unsupportedAccess: WorkerStorageInit = {
+    supported: false,
+    errorMsg: 'Access denied',
+  };
+  const { doc, self } = t.context;
+  initialize(doc, [], {} as HydrateableNode, [], [], [0, 0], unsupportedAccess, unsupportedAccess);
+  t.throws(() => doc.defaultView.localStorage, {
+    message: unsupportedAccess.errorMsg,
+  });
+  t.throws(() => self.localStorage, { message: unsupportedAccess.errorMsg });
+  t.throws(() => doc.defaultView.sessionStorage, {
+    message: unsupportedAccess.errorMsg,
+  });
+  t.throws(() => self.sessionStorage, { message: unsupportedAccess.errorMsg });
+});
+
+test.serial('Should install accessible storage', (t) => {
+  const supportedAccess: WorkerStorageInit = {
+    supported: true,
+    storage: {},
+  };
+  const { doc } = t.context;
+  initialize(doc, [], {} as HydrateableNode, [], [], [0, 0], supportedAccess, supportedAccess);
+  try {
+    doc.defaultView.localStorage;
+    doc.defaultView.sessionStorage;
+    t.pass('Accessing storage did not throw.');
+  } catch (err) {
+    t.fail(err);
+  }
+});

--- a/src/worker-thread/initialize.ts
+++ b/src/worker-thread/initialize.ts
@@ -30,7 +30,7 @@ export function initialize(
   cssKeys: Array<string>,
   globalEventHandlerKeys: Array<string>,
   [innerWidth, innerHeight]: [number, number],
-  localStorageData: { [key: string]: string },
+  localStorageData: { [key: string]: string } | string,
   sessionStorageData: { [key: string]: string },
 ): void {
   addCssKeys(cssKeys);
@@ -42,6 +42,24 @@ export function initialize(
   const window = document.defaultView;
   window.innerWidth = innerWidth;
   window.innerHeight = innerHeight;
-  window.localStorage = createStorage(document, StorageLocation.Local, localStorageData);
-  window.sessionStorage = createStorage(document, StorageLocation.Session, sessionStorageData);
+  if (typeof localStorageData != 'string') {
+    window.localStorage = createStorage(document, StorageLocation.Local, localStorageData);
+  } else {
+    Object.defineProperty(window, 'localStorage', {
+      enumerable: true,
+      get: () => {
+        throw new Error(localStorageData);
+      },
+    });
+  }
+  if (typeof sessionStorageData != 'string') {
+    window.sessionStorage = createStorage(document, StorageLocation.Session, sessionStorageData);
+  } else {
+    Object.defineProperty(window, 'sessionStorage', {
+      enumerable: true,
+      get: () => {
+        throw new Error(sessionStorageData);
+      },
+    });
+  }
 }

--- a/src/worker-thread/initialize.ts
+++ b/src/worker-thread/initialize.ts
@@ -22,7 +22,6 @@ import { appendKeys as addCssKeys } from './css/CSSStyleDeclaration';
 import { createStorage } from './Storage';
 import { StorageLocation } from '../transfer/TransferrableStorage';
 import { appendGlobalEventProperties } from './dom/HTMLElement';
-import { WorkerDOMGlobalScope } from './WorkerDOMGlobalScope';
 
 export type WorkerStorageInit = { supported: true; storage: { [key: string]: string } } | { supported: false; errorMsg: string };
 
@@ -47,29 +46,12 @@ export function initialize(
   window.innerHeight = innerHeight;
   if (localStorageInit.supported) {
     window.localStorage = createStorage(document, StorageLocation.Local, localStorageInit.storage);
-    (self as any).localStorage = window.localStorage;
   } else {
-    defineThrowingGlobal(window, 'localStorage', localStorageInit.errorMsg);
+    console.warn(localStorageInit.errorMsg);
   }
   if (sessionStorageInit.supported) {
     window.sessionStorage = createStorage(document, StorageLocation.Session, sessionStorageInit.storage);
-    (self as any).sessionStorage = window.sessionStorage;
   } else {
-    defineThrowingGlobal(window, 'sessionStorage', sessionStorageInit.errorMsg);
+    console.warn(sessionStorageInit.errorMsg);
   }
-}
-
-function defineThrowingGlobal(win: WorkerDOMGlobalScope, property: string, errorMsg: string) {
-  Object.defineProperty(win, property, {
-    enumerable: true,
-    get: () => {
-      throw new Error(errorMsg);
-    },
-  });
-  Object.defineProperty(self, property, {
-    enumerable: true,
-    get: () => {
-      throw new Error(errorMsg);
-    },
-  });
 }

--- a/src/worker-thread/initialize.ts
+++ b/src/worker-thread/initialize.ts
@@ -24,7 +24,7 @@ import { StorageLocation } from '../transfer/TransferrableStorage';
 import { appendGlobalEventProperties } from './dom/HTMLElement';
 import { WorkerDOMGlobalScope } from './WorkerDOMGlobalScope';
 
-type WorkerStorageInit = { supported: true; storage: { [key: string]: string } } | { supported: false; errorMsg: string };
+export type WorkerStorageInit = { supported: true; storage: { [key: string]: string } } | { supported: false; errorMsg: string };
 
 export function initialize(
   document: Document,

--- a/src/worker-thread/initialize.ts
+++ b/src/worker-thread/initialize.ts
@@ -23,7 +23,7 @@ import { createStorage } from './Storage';
 import { StorageLocation } from '../transfer/TransferrableStorage';
 import { appendGlobalEventProperties } from './dom/HTMLElement';
 
-export type WorkerStorageInit = { supported: true; storage: { [key: string]: string } } | { supported: false; errorMsg: string };
+export type WorkerStorageInit = { storage: { [key: string]: string } } | { errorMsg: string };
 
 export function initialize(
   document: Document,
@@ -44,12 +44,12 @@ export function initialize(
   const window = document.defaultView;
   window.innerWidth = innerWidth;
   window.innerHeight = innerHeight;
-  if (localStorageInit.supported) {
+  if ('storage' in localStorageInit) {
     window.localStorage = createStorage(document, StorageLocation.Local, localStorageInit.storage);
   } else {
     console.warn(localStorageInit.errorMsg);
   }
-  if (sessionStorageInit.supported) {
+  if ('storage' in sessionStorageInit) {
     window.sessionStorage = createStorage(document, StorageLocation.Session, sessionStorageInit.storage);
   } else {
     console.warn(sessionStorageInit.errorMsg);

--- a/src/worker-thread/initialize.ts
+++ b/src/worker-thread/initialize.ts
@@ -23,7 +23,7 @@ import { createStorage } from './Storage';
 import { StorageLocation } from '../transfer/TransferrableStorage';
 import { appendGlobalEventProperties } from './dom/HTMLElement';
 
-export type WorkerStorageInit = { storage: { [key: string]: string } } | { errorMsg: string };
+export type WorkerStorageInit = { storage: { [key: string]: string }; errorMsg: null } | { storage: null; errorMsg: string };
 
 export function initialize(
   document: Document,
@@ -44,12 +44,12 @@ export function initialize(
   const window = document.defaultView;
   window.innerWidth = innerWidth;
   window.innerHeight = innerHeight;
-  if ('storage' in localStorageInit) {
+  if (localStorageInit.storage) {
     window.localStorage = createStorage(document, StorageLocation.Local, localStorageInit.storage);
   } else {
     console.warn(localStorageInit.errorMsg);
   }
-  if ('storage' in sessionStorageInit) {
+  if (sessionStorageInit.storage) {
     window.sessionStorage = createStorage(document, StorageLocation.Session, sessionStorageInit.storage);
   } else {
     console.warn(sessionStorageInit.errorMsg);

--- a/src/worker-thread/initialize.ts
+++ b/src/worker-thread/initialize.ts
@@ -24,6 +24,8 @@ import { StorageLocation } from '../transfer/TransferrableStorage';
 import { appendGlobalEventProperties } from './dom/HTMLElement';
 import { WorkerDOMGlobalScope } from './WorkerDOMGlobalScope';
 
+type WorkerStorageInit = { supported: true; storage: { [key: string]: string } } | { supported: false; errorMsg: string };
+
 export function initialize(
   document: Document,
   strings: Array<string>,
@@ -31,8 +33,8 @@ export function initialize(
   cssKeys: Array<string>,
   globalEventHandlerKeys: Array<string>,
   [innerWidth, innerHeight]: [number, number],
-  localStorageData: { [key: string]: string } | string,
-  sessionStorageData: { [key: string]: string },
+  localStorageInit: WorkerStorageInit,
+  sessionStorageInit: WorkerStorageInit,
 ): void {
   addCssKeys(cssKeys);
   appendGlobalEventProperties(globalEventHandlerKeys);
@@ -43,17 +45,17 @@ export function initialize(
   const window = document.defaultView;
   window.innerWidth = innerWidth;
   window.innerHeight = innerHeight;
-  if (typeof localStorageData != 'string') {
-    window.localStorage = createStorage(document, StorageLocation.Local, localStorageData);
+  if (localStorageInit.supported) {
+    window.localStorage = createStorage(document, StorageLocation.Local, localStorageInit.storage);
     (self as any).localStorage = window.localStorage;
   } else {
-    defineThrowingGlobal(window, 'localStorage', localStorageData);
+    defineThrowingGlobal(window, 'localStorage', localStorageInit.errorMsg);
   }
-  if (typeof sessionStorageData != 'string') {
-    window.sessionStorage = createStorage(document, StorageLocation.Session, sessionStorageData);
+  if (sessionStorageInit.supported) {
+    window.sessionStorage = createStorage(document, StorageLocation.Session, sessionStorageInit.storage);
     (self as any).sessionStorage = window.sessionStorage;
   } else {
-    defineThrowingGlobal(window, 'sessionStorage', sessionStorageData);
+    defineThrowingGlobal(window, 'sessionStorage', sessionStorageInit.errorMsg);
   }
 }
 


### PR DESCRIPTION
**summary**
Fixes https://github.com/ampproject/amphtml/issues/30691. Makes it so that worker-dom no longer blows up when storage access is denied by the browser.  From the worker's perspective, localStorage and sessionStorage end up as null.


- [x] Write tests.
- [ ] Need to investigate if sanitizer storage init is borked. My impression is that it serializes a promise, which I don't think does what we want. Can pursue this separately though, since if I'm right then it was already broken.