### PR TITLE
Update workflows to use Node 14.x.

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.x]
+        node-version: [14.x]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Necessary for compatibility with @kristoferbaxter/bytes.


@kristoferbaxter: do you know how the blocking CI is set up? Why is it waiting for 12.x to complete & return success given that I'm modifying to 14.x here.


EDIT: I believe there is a repo setting I don't have access to that must be flipped
