### PR TITLE
storage fixes

### DIFF
--- a/src/main-thread/commands/storage.ts
+++ b/src/main-thread/commands/storage.ts
@@ -23,12 +23,12 @@ import { MessageType, StorageValueToWorker, GetOrSet } from '../../transfer/Mess
 export const StorageProcessor: CommandExecutorInterface = (strings, nodeContext, workerContext, objectContext, config) => {
   const allowedExecution = config.executorsAllowed.includes(TransferrableMutationType.STORAGE);
 
-  const get = (location: StorageLocation, key: string | null): void => {
+  const get = (location: StorageLocation, key: string): void => {
     if (config.sanitizer && location === StorageLocation.AmpState) {
       config.sanitizer.getStorage(location, key).then((value) => {
         const message: StorageValueToWorker = {
           [TransferrableKeys.type]: MessageType.GET_STORAGE,
-          [TransferrableKeys.storageKey]: key || '',
+          [TransferrableKeys.storageKey]: key,
           [TransferrableKeys.storageLocation]: location,
           [TransferrableKeys.value]: value,
         };
@@ -80,7 +80,7 @@ export const StorageProcessor: CommandExecutorInterface = (strings, nodeContext,
 
         // TODO(choumx): Clean up key/value strings (or don't store them in the first place)
         // to avoid leaking memory.
-        const key = keyIndex >= 0 ? strings.get(keyIndex) : null;
+        const key = keyIndex >= 0 ? strings.get(keyIndex) : '';
         const value = valueIndex >= 0 ? strings.get(valueIndex) : null;
 
         if (operation === GetOrSet.GET) {

--- a/src/main-thread/commands/storage.ts
+++ b/src/main-thread/commands/storage.ts
@@ -80,8 +80,8 @@ export const StorageProcessor: CommandExecutorInterface = (strings, nodeContext,
 
         // TODO(choumx): Clean up key/value strings (or don't store them in the first place)
         // to avoid leaking memory.
-        const key = keyIndex > 0 ? strings.get(keyIndex) : null;
-        const value = valueIndex > 0 ? strings.get(valueIndex) : null;
+        const key = keyIndex >= 0 ? strings.get(keyIndex) : null;
+        const value = valueIndex >= 0 ? strings.get(valueIndex) : null;
 
         if (operation === GetOrSet.GET) {
           get(location, key);
@@ -98,8 +98,8 @@ export const StorageProcessor: CommandExecutorInterface = (strings, nodeContext,
       const keyIndex = mutations[startPosition + StorageMutationIndex.Key];
       const valueIndex = mutations[startPosition + StorageMutationIndex.Value];
 
-      const key = keyIndex > 0 ? strings.get(keyIndex) : null;
-      const value = valueIndex > 0 ? strings.get(valueIndex) : null;
+      const key = keyIndex >= 0 ? strings.get(keyIndex) : null;
+      const value = valueIndex >= 0 ? strings.get(valueIndex) : null;
 
       return {
         type: 'STORAGE',

--- a/src/main-thread/debugging.ts
+++ b/src/main-thread/debugging.ts
@@ -22,7 +22,14 @@
  * @see https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#9.4
  */
 
-import { EventToWorker, MessageType, MessageToWorker, ValueSyncToWorker, BoundingClientRectToWorker } from '../transfer/Messages';
+import {
+  EventToWorker,
+  MessageType,
+  MessageToWorker,
+  ValueSyncToWorker,
+  BoundingClientRectToWorker,
+  StorageValueToWorker,
+} from '../transfer/Messages';
 import { HydrateableNode, TransferredNode, TransferrableNodeIndex } from '../transfer/TransferrableNodes';
 import { NodeContext } from './nodes';
 import { TransferrableEvent } from '../transfer/TransferrableEvent';
@@ -78,6 +85,7 @@ const isEvent = (message: MessageToWorker): message is EventToWorker => message[
 const isValueSync = (message: MessageToWorker): message is ValueSyncToWorker => message[TransferrableKeys.type] == MessageType.SYNC;
 const isBoundingClientRect = (message: MessageToWorker): message is BoundingClientRectToWorker =>
   message[TransferrableKeys.type] === MessageType.GET_BOUNDING_CLIENT_RECT;
+const isGetStorage = (message: MessageToWorker): message is StorageValueToWorker => message[TransferrableKeys.type] === MessageType.GET_STORAGE;
 
 /**
  * @param nodeContext {NodeContext}
@@ -139,6 +147,13 @@ export function readableMessageToWorker(nodeContext: NodeContext, message: Messa
     return {
       type: 'GET_BOUNDING_CLIENT_RECT',
       target: readableTransferredNode(nodeContext, message[TransferrableKeys.target]),
+    };
+  } else if (isGetStorage(message)) {
+    return {
+      type: 'GET_STORAGE',
+      key: message[TransferrableKeys.storageKey],
+      location: message[TransferrableKeys.storageLocation],
+      value: message[TransferrableKeys.value],
     };
   } else {
     return 'Unrecognized MessageToWorker type: ' + message[TransferrableKeys.type];

--- a/src/test/main-thread/commands/storage.test.ts
+++ b/src/test/main-thread/commands/storage.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import anyTest, { TestInterface } from 'ava';
+import { StorageProcessor } from '../../../main-thread/commands/storage';
+import { StringContext } from '../../../main-thread/strings';
+import { WorkerDOMConfiguration } from '../../../main-thread/configuration';
+import { CommandExecutor } from '../../../main-thread/commands/interface';
+import { TransferrableMutationType, StorageMutationIndex } from '../../../transfer/TransferrableMutation';
+import { StorageLocation } from '../../../transfer/TransferrableStorage';
+import { GetOrSet, MessageToWorker } from '../../../transfer/Messages';
+import { WorkerContext } from '../../../main-thread/worker';
+
+const test = anyTest as TestInterface<{}>;
+
+function getStorageProcessor(strings: string[]): { processor: CommandExecutor; messages: Array<MessageToWorker> } {
+  const stringCtx = new StringContext();
+  stringCtx.storeValues(strings);
+  const messages: Array<MessageToWorker> = [];
+  const processor = StorageProcessor(
+    stringCtx,
+    undefined as any,
+    {
+      messageToWorker(msg) {
+        messages.push(msg);
+      },
+    } as WorkerContext,
+    undefined as any,
+    {
+      executorsAllowed: [TransferrableMutationType.FUNCTION_CALL],
+      sanitizer: ({
+        getStorage() {
+          return Promise.resolve({ hello: 'world' });
+        },
+      } as unknown) as Sanitizer,
+    } as WorkerDOMConfiguration,
+  );
+  return {
+    processor,
+    messages,
+  };
+}
+
+test('StorageProcessor sends storage value event to worker', async (t) => {
+  const { processor, messages } = getStorageProcessor(['key']);
+  const mutations: number[] = [];
+  mutations[StorageMutationIndex.Operation] = GetOrSet.GET;
+  mutations[StorageMutationIndex.Location] = StorageLocation.AmpState;
+  mutations[StorageMutationIndex.Key] = 0;
+
+  processor.execute(new Uint16Array(mutations), 0, true);
+  t.deepEqual(messages, []);
+});

--- a/src/test/main-thread/commands/storage.test.ts
+++ b/src/test/main-thread/commands/storage.test.ts
@@ -21,26 +21,33 @@ import { WorkerDOMConfiguration } from '../../../main-thread/configuration';
 import { CommandExecutor } from '../../../main-thread/commands/interface';
 import { TransferrableMutationType, StorageMutationIndex } from '../../../transfer/TransferrableMutation';
 import { StorageLocation } from '../../../transfer/TransferrableStorage';
-import { GetOrSet, MessageToWorker } from '../../../transfer/Messages';
+import { GetOrSet, MessageToWorker, MessageType, StorageValueToWorker } from '../../../transfer/Messages';
 import { WorkerContext } from '../../../main-thread/worker';
+import { TransferrableKeys } from '../../../transfer/TransferrableKeys';
 
 const test = anyTest as TestInterface<{}>;
 
-function getStorageProcessor(strings: string[]): { processor: CommandExecutor; messages: Array<MessageToWorker> } {
+function getStorageProcessor(
+  strings: string[],
+): {
+  processor: CommandExecutor;
+  messages: Array<MessageToWorker>;
+} {
   const stringCtx = new StringContext();
   stringCtx.storeValues(strings);
   const messages: Array<MessageToWorker> = [];
+
   const processor = StorageProcessor(
     stringCtx,
     undefined as any,
     {
-      messageToWorker(msg) {
-        messages.push(msg);
+      messageToWorker(m) {
+        messages.push(m);
       },
     } as WorkerContext,
     undefined as any,
     {
-      executorsAllowed: [TransferrableMutationType.FUNCTION_CALL],
+      executorsAllowed: [TransferrableMutationType.STORAGE],
       sanitizer: ({
         getStorage() {
           return Promise.resolve({ hello: 'world' });
@@ -56,11 +63,21 @@ function getStorageProcessor(strings: string[]): { processor: CommandExecutor; m
 
 test('StorageProcessor sends storage value event to worker', async (t) => {
   const { processor, messages } = getStorageProcessor(['key']);
-  const mutations: number[] = [];
-  mutations[StorageMutationIndex.Operation] = GetOrSet.GET;
-  mutations[StorageMutationIndex.Location] = StorageLocation.AmpState;
-  mutations[StorageMutationIndex.Key] = 0;
+  const mutation: number[] = [];
+  mutation[StorageMutationIndex.Operation] = GetOrSet.GET;
+  mutation[StorageMutationIndex.Location] = StorageLocation.AmpState;
+  mutation[StorageMutationIndex.Key] = 0;
+  const mutations = new Uint16Array(mutation);
 
-  processor.execute(new Uint16Array(mutations), 0, true);
-  t.deepEqual(messages, []);
+  processor.execute(mutations, 0, true);
+  await Promise.resolve(setTimeout);
+
+  const expectedMessage: StorageValueToWorker = {
+    [TransferrableKeys.type]: MessageType.GET_STORAGE,
+    [TransferrableKeys.storageKey]: 'key',
+    [TransferrableKeys.storageLocation]: StorageLocation.AmpState,
+    [TransferrableKeys.value]: { hello: 'world' },
+  };
+  t.is(messages.length, 1);
+  t.deepEqual(messages, [expectedMessage]);
 });

--- a/src/test/mutation-transfer/amp.test.ts
+++ b/src/test/mutation-transfer/amp.test.ts
@@ -32,14 +32,13 @@ const test = anyTest as TestInterface<{
 test.beforeEach((t) => {
   const document = createTestingDocument();
   const amp = new AMP(document);
-
   t.context = {
     document,
     amp,
   };
 });
 
-test.serial.cb('AMP.getState()', (t) => {
+test.serial.cb('AMP.getState(): string key', (t) => {
   const { document, amp } = t.context;
 
   let addGlobalEventListenerCalled = false;
@@ -54,6 +53,23 @@ test.serial.cb('AMP.getState()', (t) => {
   });
 
   amp.getState('foo');
+});
+
+test.serial.cb('AMP.getState(): falsy key', (t) => {
+  const { document, amp } = t.context;
+
+  let addGlobalEventListenerCalled = false;
+  document.addGlobalEventListener = () => {
+    addGlobalEventListenerCalled = true;
+  };
+
+  expectMutations(document, (mutations) => {
+    t.true(addGlobalEventListenerCalled);
+    t.deepEqual(mutations, [TransferrableMutationType.STORAGE, GetOrSet.GET, StorageLocation.AmpState, getForTesting(''), 0]);
+    t.end();
+  });
+
+  (amp as any).getState();
 });
 
 test.serial.cb('AMP.setState()', (t) => {

--- a/src/worker-thread/amp/amp.ts
+++ b/src/worker-thread/amp/amp.ts
@@ -34,8 +34,7 @@ export class AMP {
    * Returns a promise that resolves with the value of `key`.
    * @param key
    */
-  getState(key: string): Promise<{} | null> {
-    key = key || '';
+  getState(key: string = ''): Promise<{} | null> {
     return new Promise((resolve) => {
       const messageHandler = (event: MessageEvent) => {
         const message: MessageToWorker = event.data;

--- a/src/worker-thread/amp/amp.ts
+++ b/src/worker-thread/amp/amp.ts
@@ -35,6 +35,7 @@ export class AMP {
    * @param key
    */
   getState(key: string): Promise<{} | null> {
+    key = key || '';
     return new Promise((resolve) => {
       const messageHandler = (event: MessageEvent) => {
         const message: MessageToWorker = event.data;


### PR DESCRIPTION
**summary**
Fixes two bugs discovered in https://github.com/ampproject/amphtml/issues/32984. Note that both fixes are only **5 LOC**. The rest are tests. 

1. When `AMP.getState()` is called with no args, the key was recorded as undefined in worker-thread but empty string in main-thread. The fix was to coerce falsy keys to an empty string in worker-thread as well. Without this the messages would never be matched properly and worker-thread always resolved the request with `null`.
2. When the `storageKey` being requested is the 0th indexed string in StringContext, the StorageProcessor would always send over null. Essentially never a problem for a dom post-hydration, but could easily happen via `nodom`.

As a bonus change, I've also added 'GET_STORAGE' to the list of debuggable events.