### PR TITLE
Introduce sandboxed iframe mode.

### DIFF
--- a/config/rollup.main-thread.js
+++ b/config/rollup.main-thread.js
@@ -33,6 +33,7 @@ const ESModules = [
       replace({
         values: {
           WORKER_DOM_DEBUG: false,
+          IS_AMP: false,
         },
         preventAssignment: true,
       }),
@@ -56,6 +57,7 @@ const ESModules = [
       replace({
         values: {
           WORKER_DOM_DEBUG: true,
+          IS_AMP: false,
         },
         preventAssignment: true,
       }),
@@ -78,6 +80,7 @@ const ESModules = [
       replace({
         values: {
           WORKER_DOM_DEBUG: false,
+          IS_AMP: true,
         },
         preventAssignment: true,
       }),
@@ -101,6 +104,7 @@ const ESModules = [
       replace({
         values: {
           WORKER_DOM_DEBUG: true,
+          IS_AMP: true,
         },
         preventAssignment: true,
       }),
@@ -127,6 +131,7 @@ const IIFEModules = [
       replace({
         values: {
           WORKER_DOM_DEBUG: false,
+          IS_AMP: false,
         },
         preventAssignment: true,
       }),
@@ -151,6 +156,7 @@ const IIFEModules = [
       replace({
         values: {
           WORKER_DOM_DEBUG: true,
+          IS_AMP: false,
         },
         preventAssignment: true,
       }),

--- a/demo/index.html
+++ b/demo/index.html
@@ -25,6 +25,7 @@
     <li><a href='default-input-listener/'>Default Input Listener</a></li>
     <li><a href='call-function/'>Call Function</a></li>
     <li><a href='iframe/'>Iframed storage</a></li>
+    <li><a href='sandboxed/'>Sandboxed Worker (via iframe)</a></li>
     <li><a href='scroll-into-view/'>Scroll into view</a></li>
   </ul>
 

--- a/demo/sandboxed/index.html
+++ b/demo/sandboxed/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>IframeWorker Sandbox</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="/dist/amp-debug/main.mjs" type="module"></script>
+  </head>
+  <body>
+    <div src="../hello-world/hello-world.js" id="upgrade-me">
+      <div class="root">
+        <button>Insert Hello World!</button>
+      </div>
+    </div>
+    <script type="module">
+      import { upgradeElement } from '/dist/amp-debug/main.mjs';
+      upgradeElement(
+        document.getElementById('upgrade-me'),
+        '/dist/amp-debug/worker/worker.mjs',
+        () => {},
+        undefined,
+        { iframeUrl: 'sandbox-iframe.html' }
+      ).then((worker) => {
+        worker.onmessage = (msg) =>
+          console.log(`onmessage: ${JSON.stringify(msg)}`);
+        worker.onmessageerror = (msg) =>
+          console.error(`msgerror ${JSON.stringify(msg)}`);
+        worker.onerror = (msg) =>
+          console.error(`error: ${JSON.stringify(msg)}`);
+      });
+    </script>
+  </body>
+</html>

--- a/demo/sandboxed/index.html
+++ b/demo/sandboxed/index.html
@@ -7,7 +7,7 @@
     <script src="/dist/amp-debug/main.mjs" type="module"></script>
   </head>
   <body>
-    <div src="../hello-world/hello-world.js" id="upgrade-me">
+    <div src="/hello-world/hello-world.js" id="upgrade-me">
       <div class="root">
         <button>Insert Hello World!</button>
       </div>

--- a/demo/sandboxed/sandbox-iframe.html
+++ b/demo/sandboxed/sandbox-iframe.html
@@ -1,0 +1,65 @@
+<html>
+  <script>
+    // The IframeWorker contract is that it must:
+    // 1. Send a ready message.
+    // 2. Listen for the Worker code to initialize it with.
+    // 3. Proxy all messages between the Worker and Parent, including errors.
+
+    let parentOrigin = '*';
+    const MESSAGE_TYPES = {
+      ready: 'iframe-ready',
+      init: 'init-worker',
+      onmessage: 'onmessage',
+      onerror: 'onerror',
+      onmessageerror: 'onmessageerror',
+      postMessage: 'postMessage',
+    };
+    function send(type, message) {
+      if (type !== MESSAGE_TYPES.ready && parentOrigin === '*') {
+        throw new Error('Broadcast banned except for iframe-ready message.');
+      }
+      parent.postMessage({ type, message }, parentOrigin);
+    }
+
+    function listen(type, handler) {
+      window.addEventListener('message', (event) => {
+        if (event.source !== parent) {
+          return;
+        }
+        parentOrigin = event.origin;
+
+        if (event.data.type === type) {
+          handler(event.data);
+        }
+      });
+    }
+
+    // Send initialization.
+    send(MESSAGE_TYPES.ready);
+
+    let worker = null;
+    // Listen for Worker Init.
+    listen(MESSAGE_TYPES.init, ({ code }) => {
+      if (worker) {
+        return;
+      }
+      worker = new Worker(URL.createObjectURL(new Blob([code])));
+
+      // Proxy messages Worker to parent Window.
+      worker.onmessage = (e) => send(MESSAGE_TYPES.onmessage, e.data);
+      worker.onmessageerror = (e) => send(MESSAGE_TYPES.onmessageerror, e.data);
+      worker.onerror = (e) =>
+        send(MESSAGE_TYPES.onerror, {
+          lineno: e.lineno,
+          colno: e.colno,
+          message: e.message,
+          filename: e.filename,
+        });
+
+      // Proxy message from parent Window to Worker.
+      listen(MESSAGE_TYPES.postMessage, ({ message }) =>
+        worker.postMessage(message)
+      );
+    });
+  </script>
+</html>

--- a/demo/sandboxed/sandbox-iframe.html
+++ b/demo/sandboxed/sandbox-iframe.html
@@ -1,10 +1,8 @@
 <html>
   <script>
-    // The IframeWorker contract is that it must:
-    // 1. Send a ready message.
-    // 2. Listen for the Worker code to initialize it with.
-    // 3. Proxy all messages between the Worker and Parent, including errors.
-
+    /**
+     * See `iframe-worker.ts` for the iframe proxy contract.
+     */
     let parentOrigin = '*';
     const MESSAGE_TYPES = {
       ready: 'iframe-ready',

--- a/package.json
+++ b/package.json
@@ -90,10 +90,10 @@
       "./dist/amp-production/**/*.(js|mjs)"
     ],
     "./dist/main.mjs": {
-      "brotli": "4 kB"
+      "brotli": "4.5 kB"
     },
     "./dist/main.js": {
-      "brotli": "5 kB"
+      "brotli": "5.5 kB"
     },
     "./dist/worker/worker.mjs": {
       "brotli": "12 kB"
@@ -102,7 +102,7 @@
       "brotli": "13.5 kB"
     },
     "./dist/amp-production/main.mjs": {
-      "brotli": "4 kB"
+      "brotli": "4.5 kB"
     },
     "./dist/amp-production/worker/worker.mjs": {
       "brotli": "13 kB"

--- a/package.json
+++ b/package.json
@@ -90,10 +90,10 @@
       "./dist/amp-production/**/*.(js|mjs)"
     ],
     "./dist/main.mjs": {
-      "brotli": "4.5 kB"
+      "brotli": "4 kB"
     },
     "./dist/main.js": {
-      "brotli": "5.5 kB"
+      "brotli": "5 kB"
     },
     "./dist/worker/worker.mjs": {
       "brotli": "12 kB"

--- a/src/main-thread/configuration.ts
+++ b/src/main-thread/configuration.ts
@@ -46,6 +46,8 @@ export interface InboundWorkerDOMConfiguration {
   hydrateFilter?: HydrationFilterPredicate;
   // Executor Filter, allow list
   executorsAllowed?: Array<number>;
+  // Extra layer of sandboxing by placing Worker inside of iframe.
+  sandbox?: { iframeUrl: string };
 
   // ---- Optional Callbacks
   // Called when worker consumes the page's initial DOM state.
@@ -74,6 +76,8 @@ export interface WorkerDOMConfiguration {
   sanitizer?: Sanitizer;
   // Hydration Filter Predicate
   hydrateFilter?: HydrationFilterPredicate;
+  // Extra layer of sandboxing by placing Worker inside of iframe.
+  sandbox?: { iframeUrl: string };
 
   // ---- Optional Callbacks
   // Called when worker consumes the page's initial DOM state.

--- a/src/main-thread/exported-worker.ts
+++ b/src/main-thread/exported-worker.ts
@@ -25,7 +25,7 @@ import { TransferrableMutationType } from '../transfer/TransferrableMutation';
  * An ExportedWorker is returned by the upgradeElement API.
  * For the most part, it delegates to the underlying Worker.
  *
- * It notably removes `postMessage` support and add `callFunction`.
+ * It notably removes `postMessage` support and adds `callFunction`.
  */
 export class ExportedWorker {
   workerContext_: WorkerContext;

--- a/src/main-thread/iframe-worker.ts
+++ b/src/main-thread/iframe-worker.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type MessageFromWorker = {
+  type: 'onmessage' | 'onerror' | 'onmessageerror';
+  message: any;
+};
+export type MessageFromIframe = { type: 'iframe-ready' } | MessageFromWorker;
+export type MessageToIframe = { type: 'terminate' } | { type: 'init-worker'; code: string } | { type: 'postMessage'; message: any };
+
+/**
+ * An almost drop-in replacement for a standard Web Worker, although this one
+ * within a sandboxed cross-origin iframe for a heightened security boundary.
+ */
+class IframeWorker {
+  // Public Worker API
+  public onerror: (this: IframeWorker, ev: ErrorEvent) => any;
+  public onmessage: (this: IframeWorker, ev: MessageEvent) => any;
+  public onmessageerror: (this: IframeWorker, ev: MessageEvent) => any;
+
+  // Internal variables.
+  private iframe: HTMLIFrameElement;
+  private url: string | URL;
+
+  constructor(url: string | URL, iframeUrl: string) {
+    this.iframe = window.document.createElement('iframe');
+    this.iframe.setAttribute('sandbox', 'allow-scripts');
+    this.iframe.setAttribute('style', 'display:none');
+    this.iframe.setAttribute('src', iframeUrl);
+    this.url = url;
+
+    this.setupInit();
+    this.proxyFromWorker();
+    window.document.body.appendChild(this.iframe);
+  }
+
+  private setupInit() {
+    const listener = async (event: MessageEvent) => {
+      if (event.source != this.iframe.contentWindow) {
+        return;
+      }
+
+      const code = await fetch(this.url.toString()).then((res) => res.text());
+      if ((event.data as MessageFromIframe).type == 'iframe-ready') {
+        const msg: MessageToIframe = { type: 'init-worker', code };
+        this.iframe.contentWindow!.postMessage(msg, '*');
+      }
+      window.removeEventListener('message', listener);
+    };
+    window.addEventListener('message', listener);
+  }
+
+  private proxyFromWorker() {
+    window.addEventListener('message', (event: MessageEvent) => {
+      if (event.source != this.iframe.contentWindow) {
+        return;
+      }
+
+      const { type, message } = event.data as MessageFromWorker;
+      if (type == 'onmessage' && this.onmessage) {
+        this.onmessage({ ...event, data: message });
+      } else if (type === 'onerror' && this.onerror) {
+        this.onerror({ ...message });
+      } else if (type === 'onmessageerror' && this.onmessageerror) {
+        this.onmessageerror({ ...event, data: message });
+      }
+    });
+  }
+
+  postMessage(message: any, transferables?: Array<Transferable>) {
+    const msg: MessageToIframe = { type: 'postMessage', message };
+    this.iframe.contentWindow!.postMessage(msg, '*', transferables);
+  }
+
+  terminate() {
+    const msg: MessageToIframe = { type: 'terminate' };
+    this.iframe.contentWindow!.postMessage(msg, '*');
+    this.iframe.remove();
+  }
+
+  addEventListener() {
+    throw new Error('Unsupported operation');
+  }
+  removeEventListener() {
+    throw new Error('Unsupported operation');
+  }
+  dispatchEvent(): boolean {
+    throw new Error('Unsupported operation');
+  }
+}
+
+export { IframeWorker };

--- a/src/main-thread/iframe-worker.ts
+++ b/src/main-thread/iframe-worker.ts
@@ -73,7 +73,7 @@ class IframeWorker {
       if (type == 'onmessage' && this.onmessage) {
         this.onmessage({ ...event, data: message });
       } else if (type === 'onerror' && this.onerror) {
-        this.onerror({ ...message });
+        this.onerror(message);
       } else if (type === 'onmessageerror' && this.onmessageerror) {
         this.onmessageerror({ ...event, data: message });
       }
@@ -89,17 +89,7 @@ class IframeWorker {
     const msg: MessageToIframe = { type: 'terminate' };
     this.iframe.contentWindow!.postMessage(msg, '*');
     this.iframe.remove();
-  }
-
-  addEventListener() {
-    throw new Error('Unsupported operation');
-  }
-  removeEventListener() {
-    throw new Error('Unsupported operation');
-  }
-  dispatchEvent(): boolean {
-    throw new Error('Unsupported operation');
-  }
+  } 
 }
 
 export { IframeWorker };

--- a/src/main-thread/index.amp.ts
+++ b/src/main-thread/index.amp.ts
@@ -45,6 +45,7 @@ export function upgradeElement(
   domURL: string,
   longTask?: LongTaskFunction,
   sanitizer?: Sanitizer,
+  sandbox?: { iframeUrl: string },
 ): Promise<ExportedWorker | null> {
   const authorURL = baseElement.getAttribute('src');
   if (authorURL) {
@@ -54,6 +55,7 @@ export function upgradeElement(
       longTask,
       hydrateFilter,
       sanitizer,
+      sandbox,
     });
   }
   return Promise.resolve(null);

--- a/src/main-thread/main-thread.d.ts
+++ b/src/main-thread/main-thread.d.ts
@@ -77,3 +77,4 @@ type RenderableElement = (HTMLElement | SVGElement | Text | Comment) & {
 };
 
 declare const WORKER_DOM_DEBUG: boolean;
+declare const IS_AMP: boolean;

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -22,6 +22,9 @@ import { NodeContext } from './nodes';
 import { TransferrableKeys } from '../transfer/TransferrableKeys';
 import { StorageLocation } from '../transfer/TransferrableStorage';
 
+// TODO: Have rollup remove this from non-AMP builds.
+import { IframeWorker } from './iframe-worker';
+
 // TODO: Sanitizer storage init is likely broken, since the code currently
 // attempts to stringify a Promise.
 export type StorageInit = { storage: Storage | Promise<StorageValue>; errorMsg: null } | { storage: null; errorMsg: string };
@@ -80,7 +83,11 @@ export class WorkerContext {
       }).call(self);
       ${authorScript}
       //# sourceURL=${encodeURI(config.authorURL)}`;
-    this[TransferrableKeys.worker] = new Worker(URL.createObjectURL(new Blob([code])));
+    if (!config.sandbox) {
+      this[TransferrableKeys.worker] = new Worker(URL.createObjectURL(new Blob([code])));
+    } else {
+      this[TransferrableKeys.worker] = new IframeWorker(URL.createObjectURL(new Blob([code])), config.sandbox.iframeUrl) as Worker;
+    }
     if (WORKER_DOM_DEBUG) {
       console.info('debug', 'hydratedNode', readableHydrateableRootNode(baseElement, config, this));
     }

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -20,7 +20,7 @@ import { createHydrateableRootNode } from './serialize';
 import { readableHydrateableRootNode, readableMessageToWorker } from './debugging';
 import { NodeContext } from './nodes';
 import { TransferrableKeys } from '../transfer/TransferrableKeys';
-import { StorageLocation } from '../transfer/TransferrableStorage'; 
+import { StorageLocation } from '../transfer/TransferrableStorage';
 import { IframeWorker } from './iframe-worker';
 
 // TODO: Sanitizer storage init is likely broken, since the code currently
@@ -83,7 +83,7 @@ export class WorkerContext {
       //# sourceURL=${encodeURI(config.authorURL)}`;
     if (!config.sandbox) {
       this[TransferrableKeys.worker] = new Worker(URL.createObjectURL(new Blob([code])));
-    } else if (IS_AMP){
+    } else if (IS_AMP) {
       this[TransferrableKeys.worker] = new IframeWorker(URL.createObjectURL(new Blob([code])), config.sandbox.iframeUrl);
     }
     if (WORKER_DOM_DEBUG) {

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -85,7 +85,7 @@ export class WorkerContext {
       //# sourceURL=${encodeURI(config.authorURL)}`;
     if (!config.sandbox) {
       this[TransferrableKeys.worker] = new Worker(URL.createObjectURL(new Blob([code])));
-    } else {
+    } else if (IS_AMP && config.sandbox){
       this[TransferrableKeys.worker] = new IframeWorker(URL.createObjectURL(new Blob([code])), config.sandbox.iframeUrl) as Worker;
     }
     if (WORKER_DOM_DEBUG) {

--- a/src/main-thread/worker.ts
+++ b/src/main-thread/worker.ts
@@ -20,16 +20,14 @@ import { createHydrateableRootNode } from './serialize';
 import { readableHydrateableRootNode, readableMessageToWorker } from './debugging';
 import { NodeContext } from './nodes';
 import { TransferrableKeys } from '../transfer/TransferrableKeys';
-import { StorageLocation } from '../transfer/TransferrableStorage';
-
-// TODO: Have rollup remove this from non-AMP builds.
+import { StorageLocation } from '../transfer/TransferrableStorage'; 
 import { IframeWorker } from './iframe-worker';
 
 // TODO: Sanitizer storage init is likely broken, since the code currently
 // attempts to stringify a Promise.
 export type StorageInit = { storage: Storage | Promise<StorageValue>; errorMsg: null } | { storage: null; errorMsg: string };
 export class WorkerContext {
-  private [TransferrableKeys.worker]: Worker;
+  private [TransferrableKeys.worker]: Worker | IframeWorker;
   private nodeContext: NodeContext;
   private config: WorkerDOMConfiguration;
 
@@ -85,8 +83,8 @@ export class WorkerContext {
       //# sourceURL=${encodeURI(config.authorURL)}`;
     if (!config.sandbox) {
       this[TransferrableKeys.worker] = new Worker(URL.createObjectURL(new Blob([code])));
-    } else if (IS_AMP && config.sandbox){
-      this[TransferrableKeys.worker] = new IframeWorker(URL.createObjectURL(new Blob([code])), config.sandbox.iframeUrl) as Worker;
+    } else if (IS_AMP){
+      this[TransferrableKeys.worker] = new IframeWorker(URL.createObjectURL(new Blob([code])), config.sandbox.iframeUrl);
     }
     if (WORKER_DOM_DEBUG) {
       console.info('debug', 'hydratedNode', readableHydrateableRootNode(baseElement, config, this));
@@ -99,7 +97,7 @@ export class WorkerContext {
   /**
    * Returns the private worker.
    */
-  get worker(): Worker {
+  get worker(): Worker | IframeWorker {
     return this[TransferrableKeys.worker];
   }
 

--- a/src/test/main-thread/iframe-worker.test.ts
+++ b/src/test/main-thread/iframe-worker.test.ts
@@ -36,7 +36,7 @@ test.beforeEach((t) => {
     Promise.resolve({
       text: () => Promise.resolve(blob.toString().slice('BLOB:'.length)),
     }) as any;
-  const worker = new IframeWorker(URL.createObjectURL(new Blob(['worker code'])), 'https://example.com' as any);
+  const worker = new IframeWorker(URL.createObjectURL(new Blob(['worker code'])), 'https://example.com');
   const iframe = (worker as any).iframe as HTMLIFrameElement;
 
   const oldPostMessage = iframe.contentWindow!.postMessage.bind(iframe.contentWindow);

--- a/src/test/main-thread/iframe-worker.test.ts
+++ b/src/test/main-thread/iframe-worker.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import anyTest, { TestInterface } from 'ava';
+import { Env } from './helpers/env';
+import { IframeWorker, MessageToIframe, MessageFromIframe } from '../../main-thread/iframe-worker';
+
+const test = anyTest as TestInterface<{
+  env: Env;
+  fakeReceiveMessage: (msg: MessageFromIframe) => void;
+  sentToIframe: MessageToIframe[];
+  worker: IframeWorker;
+}>;
+
+test.beforeEach((t) => {
+  const env = new Env();
+  const sentToIframe: MessageToIframe[] = [];
+
+  const messageListeners: any = [];
+  env.window.addEventListener = (type: string, listener: any) => messageListeners.push(listener);
+
+  global.fetch = (blob: any) =>
+    Promise.resolve({
+      text: () => Promise.resolve(blob.toString().slice('BLOB:'.length)),
+    }) as any;
+  const worker = new IframeWorker(URL.createObjectURL(new Blob(['worker code'])), 'https://example.com' as any);
+  const iframe = (worker as any).iframe as HTMLIFrameElement;
+
+  const oldPostMessage = iframe.contentWindow!.postMessage.bind(iframe.contentWindow);
+  iframe.contentWindow!.postMessage = (msg, targetOrigin, transferables) => {
+    sentToIframe.push(msg);
+    oldPostMessage(msg, targetOrigin, transferables);
+  };
+
+  function sendFromIframe(msg: Object): void {
+    for (let listener of messageListeners) {
+      listener({ data: msg, source: iframe.contentWindow });
+    }
+  }
+
+  t.context = {
+    env: new Env(),
+    fakeReceiveMessage: sendFromIframe,
+    sentToIframe,
+    worker,
+  };
+});
+test('No messages sent to subframe until it declares iframe-ready.', async (t) => {
+  const { sentToIframe } = t.context;
+  await new Promise(setTimeout as any);
+  t.is(sentToIframe.length, 0);
+});
+
+test('Should listen for and respond to an iframe-ready signal.', async (t) => {
+  const { fakeReceiveMessage, sentToIframe } = t.context;
+  fakeReceiveMessage({ type: 'iframe-ready' });
+  await new Promise(setTimeout as any);
+
+  t.is(sentToIframe.length, 1);
+  t.deepEqual(sentToIframe, [
+    {
+      type: 'init-worker',
+      code: 'worker code',
+    },
+  ]);
+});
+
+test('Should proxy postMessage calls.', async (t) => {
+  const { worker, sentToIframe } = t.context;
+  worker.postMessage({ hello: 'world' });
+
+  t.is(sentToIframe.length, 1);
+  t.deepEqual(sentToIframe, [
+    {
+      type: 'postMessage',
+      message: { hello: 'world' },
+    },
+  ]);
+});
+
+test('Should proxy iframed worker messages.', async (t) => {
+  const { worker, fakeReceiveMessage } = t.context;
+  const onmessageMessages: MessageEvent[] = [];
+  const onerrorMessages: ErrorEvent[] = [];
+  const onmessageerrorMessages: MessageEvent[] = [];
+
+  worker.onmessage = (msg: MessageEvent) => onmessageMessages.push(msg);
+  worker.onmessageerror = (msg: MessageEvent) => onmessageerrorMessages.push(msg);
+  worker.onerror = (msg: ErrorEvent) => onerrorMessages.push(msg);
+
+  fakeReceiveMessage({ type: 'onmessage', message: { onmessage: 1 } });
+  fakeReceiveMessage({ type: 'onmessage', message: { onmessage: 2 } });
+
+  fakeReceiveMessage({ type: 'onerror', message: { onerror: 1 } });
+  fakeReceiveMessage({
+    type: 'onmessageerror',
+    message: { onmessageerror: 1 },
+  });
+
+  t.is(onmessageMessages.length, 2);
+  t.is(onmessageerrorMessages.length, 1);
+  t.is(onerrorMessages.length, 1);
+});
+
+test('Should send terminate message', (t) => {
+  const { worker, sentToIframe } = t.context;
+  worker.terminate();
+  t.deepEqual(sentToIframe, [{ type: 'terminate' }]);
+});


### PR DESCRIPTION
**background**
The primary use-case of `worker-dom` is to power [`<amp-script>`](https://amp.dev/documentation/components/amp-script/).  With the current mechanisms in place, it acts well for 1p (mostly trusted) scripts. `amp-script` now has a new [use case](https://github.com/ampproject/amphtml/issues/30193) to allow less-trusted 3p scripts to run on the page without a CSP, and for this we need a stronger security boundary.

The goal of this PR is to enable a "sandboxed" mode by creating the Worker within a sandboxed iframe instead of within the main frame.

**design**

When starting up, `worker-dom` will create an iframe instead of a WebWorker. This iframe needs to perform a handshaking process and then essentially act as a proxy between the subframe Worker and the main frame. To make implementation as simple as possible, I've created a class called `IframeWorker` that presents almost the exact same API surface as a standard Worker.

The iframe must follow a specific contract:
1. When initialized, send out a message `{type: 'iframe-ready'}`
2. When receiving a message with shape: `{type: 'init-worker', code: string}`, create a Worker with the specified code.
3. Proxy all messages received via shape `{type: 'postMessage', message: string}` to the subframe Worker.
4.  Proxy all messages received from the Worker back to the parent. The shape of should be: `{type: 'onmessage' | 'onerror', message: string }`

In order to take advantage of this feature, consumers will need to use the new option in the `upgradeElement` API called `sandboxed`. The option may remain undefined to men _off_, or be an object with the key `iframeUrl`. The specified iframe must follow the contract described above. An example is provided in the demo folder.

**hosting the iframe**
Depending on whether we want to release this for non-AMP mode as well, we could also have a default value for `iframeUrl` that points to a Github Pages hosted iframe.
 
 ~~**note**: There is some drift in our src code alignment in `prettier` and I've extracted that to a small separate PR: https://github.com/ampproject/worker-dom/pull/1041~~