### PR TITLE
create new server-build, for server side use cases

### DIFF
--- a/config/rollup.worker-thread.js
+++ b/config/rollup.worker-thread.js
@@ -32,6 +32,28 @@ const compilePlugins = [
 // but ensure the code can be run within a worker by putting it inside a named iife.
 const ESModules = [
   {
+    input: 'output/worker-thread/server-lib.js',
+    output: {
+      file: 'dist/server-lib.mjs',
+      format: 'es',
+      name: 'ServerLib',
+      sourcemap: true,
+    },
+    plugins: [
+      replace({
+        values: {
+          WORKER_DOM_DEBUG: false,
+        },
+        preventAssignment: true,
+      }),
+      babelPlugin({
+        transpileToES5: false,
+        allowConsole: false,
+      }),
+      ...compilePlugins,
+    ],
+  },
+  {
     input: 'output/worker-thread/index.js',
     output: {
       file: 'dist/worker/worker.mjs',

--- a/src/worker-thread/server-lib.ts
+++ b/src/worker-thread/server-lib.ts
@@ -1,0 +1,7 @@
+import { Document } from './dom/Document';
+import { GlobalScope } from './WorkerDOMGlobalScope';
+
+export function createDocument() {
+  const win: GlobalScope = {} as any;
+  return new Document(win);
+}


### PR DESCRIPTION
**summary**

Creates a new binary for server-side usage.  

**Sample API Usage**

```js
import {createDocument} from 'worker-dom/server-lib'
const doc = createDocument();
const body = doc.createElement('body');
doc.appendChild(body);
console.log(doc.body.outerHTML) --> <body></body>
```

Note: this is super experimental and is very likely to change over the coming months