### PR TITLE
nodom: support storage

### DIFF
--- a/src/test/main-thread/initialize-storage.test.ts
+++ b/src/test/main-thread/initialize-storage.test.ts
@@ -15,7 +15,8 @@
  */
 
 import anyTest, { TestInterface } from 'ava';
-import { initialize, WorkerStorageInit } from '../../worker-thread/initialize';
+import { initialize } from '../../worker-thread/initialize';
+import { WorkerStorageInit } from '../../worker-thread/initialize-storage';
 import { Document } from '../../worker-thread/dom/Document';
 import { HydrateableNode } from '../../transfer/TransferrableNodes';
 

--- a/src/worker-thread/hydrate.d.ts
+++ b/src/worker-thread/hydrate.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/worker-thread/hydrate.ts
+++ b/src/worker-thread/hydrate.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Document } from './dom/Document';
+import type { HydrateableNode } from '../transfer/TransferrableNodes';
+import type { WorkerStorageInit } from './initialize-storage';
+
+export type HydrateFunction = (
+  document: Document,
+  strings: Array<string>,
+  hydrateableNode: HydrateableNode,
+  cssKeys: Array<string>,
+  globalEventHandlerKeys: Array<string>,
+  [innerWidth, innerHeight]: [number, number],
+  localStorageInit: WorkerStorageInit,
+  sessionStorageInit: WorkerStorageInit,
+) => void;

--- a/src/worker-thread/index.amp.ts
+++ b/src/worker-thread/index.amp.ts
@@ -63,6 +63,7 @@ import { GlobalScope, WorkerDOMGlobalScope } from './WorkerDOMGlobalScope';
 import { initialize } from './initialize';
 import { rafPolyfill, cafPolyfill } from './AnimationFrame';
 import { wrap as longTaskWrap } from './long-task';
+import { HydrateFunction } from './hydrate';
 
 declare const WORKER_DOM_DEBUG: boolean;
 
@@ -163,4 +164,4 @@ export const workerDOM: WorkerDOMGlobalScope = (function (postMessage, addEventL
 (self as any).exportFunction = exportFunction;
 addEventListener('message', (evt: MessageEvent) => callFunctionMessageHandler(evt, workerDOM.document));
 
-export const hydrate = initialize;
+export const hydrate: HydrateFunction = initialize;

--- a/src/worker-thread/index.nodom.amp.ts
+++ b/src/worker-thread/index.nodom.amp.ts
@@ -20,6 +20,7 @@ import { AMP } from './amp/amp';
 import { DocumentStub } from './dom/DocumentLite';
 import { callFunctionMessageHandler, exportFunction } from './function';
 import { deleteGlobals } from './amp/delete-globals';
+import { initializeStorage, WorkerStorageInit } from './initialize';
 
 const noop = () => void 0;
 
@@ -43,4 +44,16 @@ deleteGlobals(self);
 (self as any).exportFunction = exportFunction;
 addEventListener('message', (evt: MessageEvent) => callFunctionMessageHandler(evt, workerDOM.document));
 
-export const hydrate = noop;
+// Must match the same signature of hydrate in index.amp.ts.
+export function hydrate(
+  document: DocumentStub,
+  strings: Object,
+  hydrateableNode: Object,
+  cssKeys: Object,
+  globalEventHandlerKeys: Object,
+  size: Object,
+  localStorageInit: WorkerStorageInit,
+  sessionStorageInit: WorkerStorageInit,
+) {
+  initializeStorage(document, localStorageInit, sessionStorageInit);
+}

--- a/src/worker-thread/index.nodom.amp.ts
+++ b/src/worker-thread/index.nodom.amp.ts
@@ -20,7 +20,7 @@ import { AMP } from './amp/amp';
 import { DocumentStub } from './dom/DocumentLite';
 import { callFunctionMessageHandler, exportFunction } from './function';
 import { deleteGlobals } from './amp/delete-globals';
-import { initializeStorage, WorkerStorageInit } from './initialize';
+import { initializeStorage, WorkerStorageInit } from './initialize-storage';
 
 const noop = () => void 0;
 

--- a/src/worker-thread/index.nodom.amp.ts
+++ b/src/worker-thread/index.nodom.amp.ts
@@ -15,13 +15,13 @@
  */
 
 import type { WorkerNoDOMGlobalScope } from './WorkerDOMGlobalScope';
+import type { HydrateFunction } from './hydrate';
 
 import { AMP } from './amp/amp';
 import { DocumentStub } from './dom/DocumentLite';
 import { callFunctionMessageHandler, exportFunction } from './function';
 import { deleteGlobals } from './amp/delete-globals';
-import { initializeStorage, WorkerStorageInit } from './initialize-storage';
-import { HydrateFunction } from './hydrate';
+import { initializeStorage } from './initialize-storage';
 
 const noop = () => void 0;
 

--- a/src/worker-thread/index.nodom.amp.ts
+++ b/src/worker-thread/index.nodom.amp.ts
@@ -21,6 +21,7 @@ import { DocumentStub } from './dom/DocumentLite';
 import { callFunctionMessageHandler, exportFunction } from './function';
 import { deleteGlobals } from './amp/delete-globals';
 import { initializeStorage, WorkerStorageInit } from './initialize-storage';
+import { HydrateFunction } from './hydrate';
 
 const noop = () => void 0;
 
@@ -44,8 +45,7 @@ deleteGlobals(self);
 (self as any).exportFunction = exportFunction;
 addEventListener('message', (evt: MessageEvent) => callFunctionMessageHandler(evt, workerDOM.document));
 
-// Must match the same signature of hydrate in index.amp.ts.
-export function hydrate(
+export const hydrate: HydrateFunction = (
   document: DocumentStub,
   strings: Object,
   hydrateableNode: Object,
@@ -54,6 +54,6 @@ export function hydrate(
   size: Object,
   localStorageInit: WorkerStorageInit,
   sessionStorageInit: WorkerStorageInit,
-) {
+) => {
   initializeStorage(document, localStorageInit, sessionStorageInit);
-}
+};

--- a/src/worker-thread/index.nodom.amp.ts
+++ b/src/worker-thread/index.nodom.amp.ts
@@ -16,6 +16,7 @@
 
 import type { WorkerNoDOMGlobalScope } from './WorkerDOMGlobalScope';
 import type { HydrateFunction } from './hydrate';
+import type { WorkerStorageInit } from './initialize-storage';
 
 import { AMP } from './amp/amp';
 import { DocumentStub } from './dom/DocumentLite';

--- a/src/worker-thread/index.ts
+++ b/src/worker-thread/index.ts
@@ -59,6 +59,7 @@ import { Document } from './dom/Document';
 import { initialize } from './initialize';
 import { Event as WorkerDOMEvent } from './Event';
 import { rafPolyfill, cafPolyfill } from './AnimationFrame';
+import { HydrateFunction } from './hydrate';
 
 const globalScope: GlobalScope = {
   innerWidth: 0,
@@ -131,4 +132,4 @@ export const workerDOM = (function (postMessage, addEventListener, removeEventLi
   return document.defaultView;
 })(postMessage.bind(self) || noop, addEventListener.bind(self) || noop, removeEventListener.bind(self) || noop);
 
-export const hydrate = initialize;
+export const hydrate: HydrateFunction = initialize;

--- a/src/worker-thread/initialize-storage.ts
+++ b/src/worker-thread/initialize-storage.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/worker-thread/initialize-storage.ts
+++ b/src/worker-thread/initialize-storage.ts
@@ -16,6 +16,7 @@
 
 import type { Document } from './dom/Document';
 import type { DocumentStub } from './dom/DocumentLite';
+
 import { createStorage } from './Storage';
 import { StorageLocation } from '../transfer/TransferrableStorage';
 

--- a/src/worker-thread/initialize-storage.ts
+++ b/src/worker-thread/initialize-storage.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Document } from './dom/Document';
+import type { DocumentStub } from './dom/DocumentLite';
+import { createStorage } from './Storage';
+import { StorageLocation } from '../transfer/TransferrableStorage';
+
+export type WorkerStorageInit = { storage: { [key: string]: string }; errorMsg: null } | { storage: null; errorMsg: string };
+
+export function initializeStorage(document: Document | DocumentStub, localStorageInit: WorkerStorageInit, sessionStorageInit: WorkerStorageInit) {
+  const window = document.defaultView;
+  if (localStorageInit.storage) {
+    window.localStorage = createStorage(document, StorageLocation.Local, localStorageInit.storage);
+  } else {
+    console.warn(localStorageInit.errorMsg);
+  }
+  if (sessionStorageInit.storage) {
+    window.sessionStorage = createStorage(document, StorageLocation.Session, sessionStorageInit.storage);
+  } else {
+    console.warn(sessionStorageInit.errorMsg);
+  }
+}

--- a/src/worker-thread/initialize-storage.ts
+++ b/src/worker-thread/initialize-storage.ts
@@ -20,7 +20,9 @@ import type { DocumentStub } from './dom/DocumentLite';
 import { createStorage } from './Storage';
 import { StorageLocation } from '../transfer/TransferrableStorage';
 
-export type WorkerStorageInit = { storage: { [key: string]: string }; errorMsg: null } | { storage: null; errorMsg: string };
+type InitStorageMap = { storage: { [key: string]: string }; errorMsg: null };
+type InitStorageError = { storage: null; errorMsg: string };
+export type WorkerStorageInit = InitStorageMap | InitStorageError;
 
 export function initializeStorage(document: Document | DocumentStub, localStorageInit: WorkerStorageInit, sessionStorageInit: WorkerStorageInit) {
   const window = document.defaultView;

--- a/src/worker-thread/initialize.ts
+++ b/src/worker-thread/initialize.ts
@@ -16,16 +16,13 @@
 
 import type { Document } from './dom/Document';
 import type { HydrateableNode } from '../transfer/TransferrableNodes';
+import type { WorkerStorageInit } from './initialize-storage';
 
 import { store as storeString } from './strings';
 import { TransferrableKeys } from '../transfer/TransferrableKeys';
 import { appendKeys as addCssKeys } from './css/CSSStyleDeclaration';
-import { createStorage } from './Storage';
-import { StorageLocation } from '../transfer/TransferrableStorage';
 import { appendGlobalEventProperties } from './dom/HTMLElement';
-import { DocumentStub } from './dom/DocumentLite';
-
-export type WorkerStorageInit = { storage: { [key: string]: string }; errorMsg: null } | { storage: null; errorMsg: string };
+import { initializeStorage } from './initialize-storage';
 
 export function initialize(
   document: Document,
@@ -47,18 +44,4 @@ export function initialize(
   window.innerWidth = innerWidth;
   window.innerHeight = innerHeight;
   initializeStorage(document, localStorageInit, sessionStorageInit);
-}
-
-export function initializeStorage(document: Document | DocumentStub, localStorageInit: WorkerStorageInit, sessionStorageInit: WorkerStorageInit) {
-  const window = document.defaultView;
-  if (localStorageInit.storage) {
-    window.localStorage = createStorage(document, StorageLocation.Local, localStorageInit.storage);
-  } else {
-    console.warn(localStorageInit.errorMsg);
-  }
-  if (sessionStorageInit.storage) {
-    window.sessionStorage = createStorage(document, StorageLocation.Session, sessionStorageInit.storage);
-  } else {
-    console.warn(sessionStorageInit.errorMsg);
-  }
 }

--- a/src/worker-thread/initialize.ts
+++ b/src/worker-thread/initialize.ts
@@ -23,6 +23,7 @@ import { appendKeys as addCssKeys } from './css/CSSStyleDeclaration';
 import { createStorage } from './Storage';
 import { StorageLocation } from '../transfer/TransferrableStorage';
 import { appendGlobalEventProperties } from './dom/HTMLElement';
+import { DocumentStub } from './dom/DocumentLite';
 
 export type WorkerStorageInit = { storage: { [key: string]: string }; errorMsg: null } | { storage: null; errorMsg: string };
 
@@ -45,6 +46,11 @@ export function initialize(
   const window = document.defaultView;
   window.innerWidth = innerWidth;
   window.innerHeight = innerHeight;
+  initializeStorage(document, localStorageInit, sessionStorageInit);
+}
+
+export function initializeStorage(document: Document | DocumentStub, localStorageInit: WorkerStorageInit, sessionStorageInit: WorkerStorageInit) {
+  const window = document.defaultView;
   if (localStorageInit.storage) {
     window.localStorage = createStorage(document, StorageLocation.Local, localStorageInit.storage);
   } else {


### PR DESCRIPTION
**summary**
The `nodom` binary historically hasn't called `hydrate` since there is no DOM to hydrate. What I didn't realize at the time was the `LocalStorage` and `SessionStorage` are also initialized during hydration.

- This PR adds in storage support for nodom binaries.
- It also extracts storage init to its own file to avoid dragging along all of `Document` (which in turn pulls in the vdom)