### PR TITLE
nodom: workerDOM should be document.defaultView

### DIFF
--- a/src/worker-thread/MutationTransfer.ts
+++ b/src/worker-thread/MutationTransfer.ts
@@ -22,7 +22,7 @@ import { Node } from './dom/Node';
 import { Phase } from '../transfer/Phase';
 import { phase, set as setPhase } from './phase';
 import { Document } from './dom/Document';
-import { DocumentStub } from './dom/DocumentLite';
+import { DocumentStub } from './dom/DocumentStub';
 
 let pending = false;
 let pendingMutations: Array<number> = [];

--- a/src/worker-thread/Storage.ts
+++ b/src/worker-thread/Storage.ts
@@ -20,7 +20,7 @@ import { StorageLocation } from '../transfer/TransferrableStorage';
 import { TransferrableMutationType } from '../transfer/TransferrableMutation';
 import { store } from './strings';
 import { transfer } from './MutationTransfer';
-import { DocumentStub } from './dom/DocumentLite';
+import { DocumentStub } from './dom/DocumentStub';
 
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Storage

--- a/src/worker-thread/WorkerDOMGlobalScope.ts
+++ b/src/worker-thread/WorkerDOMGlobalScope.ts
@@ -56,7 +56,7 @@ import { CharacterData } from './dom/CharacterData';
 import { DocumentFragment } from './dom/DocumentFragment';
 import { DOMTokenList } from './dom/DOMTokenList';
 import { Element } from './dom/Element';
-import { DocumentStub } from './dom/DocumentLite';
+import { DocumentStub } from './dom/DocumentStub';
 
 /**
  * Should only contain properties that exist on Window.

--- a/src/worker-thread/amp/amp.ts
+++ b/src/worker-thread/amp/amp.ts
@@ -21,7 +21,7 @@ import { TransferrableKeys } from '../../transfer/TransferrableKeys';
 import { TransferrableMutationType } from '../../transfer/TransferrableMutation';
 import { store } from '../strings';
 import { transfer } from '../MutationTransfer';
-import { DocumentStub } from '../dom/DocumentLite';
+import { DocumentStub } from '../dom/DocumentStub';
 
 export class AMP {
   private document: Document | DocumentStub;

--- a/src/worker-thread/dom/DocumentStub.ts
+++ b/src/worker-thread/dom/DocumentStub.ts
@@ -33,7 +33,7 @@ export class DocumentStub {
   public [TransferrableKeys.index]: number = -1;
 
   constructor() {
-    this.defaultView = { document: this };
+    this.defaultView = Object.assign(global, { document: this });
   }
 
   public [TransferrableKeys.observe](): void {

--- a/src/worker-thread/dom/DocumentStub.ts
+++ b/src/worker-thread/dom/DocumentStub.ts
@@ -33,7 +33,7 @@ export class DocumentStub {
   public [TransferrableKeys.index]: number = -1;
 
   constructor() {
-    this.defaultView = Object.assign(global, { document: this });
+    this.defaultView = { document: this };
   }
 
   public [TransferrableKeys.observe](): void {

--- a/src/worker-thread/function.ts
+++ b/src/worker-thread/function.ts
@@ -20,7 +20,7 @@ import { MessageToWorker, MessageType, FunctionCallToWorker, ResolveOrReject } f
 import { transfer } from './MutationTransfer';
 import { TransferrableMutationType } from '../transfer/TransferrableMutation';
 import { store } from './strings';
-import { DocumentStub } from './dom/DocumentLite';
+import { DocumentStub } from './dom/DocumentStub';
 
 const exportedFunctions: { [fnIdent: string]: Function } = {};
 

--- a/src/worker-thread/index.nodom.amp.ts
+++ b/src/worker-thread/index.nodom.amp.ts
@@ -32,7 +32,7 @@ export const workerDOM: WorkerNoDOMGlobalScope = (function (postMessage, addEven
   document.postMessage = postMessage;
   document.addGlobalEventListener = addEventListener;
   document.removeGlobalEventListener = removeEventListener;
-  return { document };
+  return document.defaultView;
 })(postMessage.bind(self) || noop, addEventListener.bind(self) || noop, removeEventListener.bind(self) || noop);
 
 // Modify global scope by removing disallowed properties.

--- a/src/worker-thread/index.nodom.amp.ts
+++ b/src/worker-thread/index.nodom.amp.ts
@@ -18,7 +18,7 @@ import { HydrateFunction } from './hydrate';
 import { AMP } from './amp/amp';
 import { callFunctionMessageHandler, exportFunction } from './function';
 import { WorkerNoDOMGlobalScope } from './WorkerDOMGlobalScope';
-import { DocumentStub } from './dom/DocumentLite';
+import { DocumentStub } from './dom/DocumentStub';
 import { deleteGlobals } from './amp/delete-globals';
 import { initializeStorage } from './initialize-storage';
 import { WorkerStorageInit } from './initialize-storage';

--- a/src/worker-thread/initialize-storage.ts
+++ b/src/worker-thread/initialize-storage.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Document } from './dom/Document';
-import type { DocumentStub } from './dom/DocumentLite';
+import type { DocumentStub } from './dom/DocumentStub';
 
 import { createStorage } from './Storage';
 import { StorageLocation } from '../transfer/TransferrableStorage';


### PR DESCRIPTION
**summary**
Fixes https://github.com/ampproject/amphtml/issues/35902

1. Renames `DocumentLite.ts` to `DocumentStub.ts`. The filename should match the exported class :)
2. Modifies `workerDOM` export to actually be the `document.defaultView` which is essential for propagating properties (localStorage/sessionStorate) to the global `self`. This is also how the regular binary works. See below snippets

https://github.com/ampproject/worker-dom/blob/11ff429516e4dcfb4f64794bed5f52163d5d9166/src/main-thread/worker.ts#L80

https://github.com/ampproject/worker-dom/blob/11ff429516e4dcfb4f64794bed5f52163d5d9166/src/worker-thread/index.amp.ts#L137

**testing done**
Copied the built binaries over to a local `amphtml` and confirmed that localStorage access was available on `self`