### PR TITLE
babel loose mode compat: dont spread Set

### DIFF
--- a/src/worker-thread/dom/DOMTokenList.ts
+++ b/src/worker-thread/dom/DOMTokenList.ts
@@ -103,7 +103,11 @@ export class DOMTokenList {
    */
   public add(...tokens: string[]): void {
     const oldValue = this.value;
-    this[TransferrableKeys.tokens].splice(0, this[TransferrableKeys.tokens].length, ...new Set(this[TransferrableKeys.tokens].concat(tokens)));
+    this[TransferrableKeys.tokens].splice(
+      0,
+      this[TransferrableKeys.tokens].length,
+      ...Array.from(new Set(this[TransferrableKeys.tokens].concat(tokens))),
+    );
     this[TransferrableKeys.mutated](oldValue, this.value);
   }
 
@@ -119,7 +123,7 @@ export class DOMTokenList {
     this[TransferrableKeys.tokens].splice(
       0,
       this[TransferrableKeys.tokens].length,
-      ...new Set(this[TransferrableKeys.tokens].filter((token) => !tokens.includes(token))),
+      ...Array.from(new Set(this[TransferrableKeys.tokens].filter((token) => !tokens.includes(token)))),
     );
     this[TransferrableKeys.mutated](oldValue, this.value);
   }
@@ -142,7 +146,7 @@ export class DOMTokenList {
         set.add(newToken);
       }
     }
-    this[TransferrableKeys.tokens].splice(0, this[TransferrableKeys.tokens].length, ...set);
+    this[TransferrableKeys.tokens].splice(0, this[TransferrableKeys.tokens].length, ...Array.from(set));
     this[TransferrableKeys.mutated](oldValue, this.value);
   }
 


### PR DESCRIPTION
**summary**
It is generally useful to be compatible with Babel's loose mode. This means avoiding funky behavior in the ECMAScript spec.

A violation in worker-dom was the spreading of Sets. Technically this works in JS:
```js
assertEqual([...new Set([1,2])].join(','), '1,2');
```

But in a loose mode, spreads are assumed to only occur on Array and the results may surprise you:

```js
// Loose mode:
assertEqual([...new Set([1,2])].join(','), '[object Set]');
```