### PR TITLE
Fix off-by-1 index bug in amp state

### DIFF
--- a/src/test/mutation-transfer/amp.test.ts
+++ b/src/test/mutation-transfer/amp.test.ts
@@ -32,7 +32,7 @@ test.serial.cb('AMP.getState(): string key', (t) => {
 
   expectMutations(document, (mutations) => {
     t.true(addGlobalEventListenerCalled);
-    t.deepEqual(mutations, [TransferrableMutationType.STORAGE, GetOrSet.GET, StorageLocation.AmpState, getForTesting('foo'), 0]);
+    t.deepEqual(mutations, [TransferrableMutationType.STORAGE, GetOrSet.GET, StorageLocation.AmpState, getForTesting('foo')! + 1, 0]);
     t.end();
   });
 
@@ -49,7 +49,7 @@ test.serial.cb('AMP.getState(): falsy key', (t) => {
 
   expectMutations(document, (mutations) => {
     t.true(addGlobalEventListenerCalled);
-    t.deepEqual(mutations, [TransferrableMutationType.STORAGE, GetOrSet.GET, StorageLocation.AmpState, getForTesting(''), 0]);
+    t.deepEqual(mutations, [TransferrableMutationType.STORAGE, GetOrSet.GET, StorageLocation.AmpState, getForTesting('')! + 1, 0]);
     t.end();
   });
 
@@ -60,7 +60,7 @@ test.serial.cb('AMP.setState()', (t) => {
   const { document, amp } = t.context;
 
   expectMutations(document, (mutations) => {
-    t.deepEqual(mutations, [TransferrableMutationType.STORAGE, GetOrSet.SET, StorageLocation.AmpState, 0, getForTesting('{"foo":"bar"}')]);
+    t.deepEqual(mutations, [TransferrableMutationType.STORAGE, GetOrSet.SET, StorageLocation.AmpState, 0, getForTesting('{"foo":"bar"}')! + 1]);
     t.end();
   });
 

--- a/src/worker-thread/amp/amp.ts
+++ b/src/worker-thread/amp/amp.ts
@@ -37,7 +37,7 @@ export class AMP {
       };
 
       this.document.addGlobalEventListener('message', messageHandler);
-      transfer(this.document, [TransferrableMutationType.STORAGE, GetOrSet.GET, StorageLocation.AmpState, /* key */ store(key), /* value */ 0]);
+      transfer(this.document, [TransferrableMutationType.STORAGE, GetOrSet.GET, StorageLocation.AmpState, /* key */ store(key) + 1, /* value */ 0]);
       setTimeout(resolve, 500, null); // TODO: Why a magical constant, define and explain.
     });
   }
@@ -54,6 +54,6 @@ export class AMP {
     } catch (e) {
       throw new Error(`AMP.setState only accepts valid JSON as input.`);
     }
-    transfer(this.document, [TransferrableMutationType.STORAGE, GetOrSet.SET, StorageLocation.AmpState, /* key */ 0, /* value */ store(stringified)]);
+    transfer(this.document, [TransferrableMutationType.STORAGE, GetOrSet.SET, StorageLocation.AmpState, /* key */ 0, /* value */ store(stringified) + 1]);
   }
 }


### PR DESCRIPTION
https://github.com/ampproject/worker-dom/commit/a6bcd6f515de985c6dc48e013e57757eb6b8d962 changed the indice by adding 1 to all SET/GET operation. However, amp.js is not updated.

Fixes https://github.com/ampproject/amphtml/issues/39016 (will need to release worker-dom and update depencency on amphtml though)

Uncertain on what is the best way to cover this scenario by test, but could be a further work.

It appears that this change will only affect amp.