### PR TITLE
Unsubscription/removing "on" listener must not cause an error

### DIFF
--- a/src/test/htmlelement/globalEventProperties.test.ts
+++ b/src/test/htmlelement/globalEventProperties.test.ts
@@ -2,6 +2,7 @@ import anyTest, { TestInterface } from 'ava';
 import { HTMLElement, appendGlobalEventProperties } from '../../worker-thread/dom/HTMLElement';
 import { createTestingDocument } from '../DocumentCreation';
 import { Document } from '../../worker-thread/dom/Document';
+import { Event } from '../../worker-thread/Event';
 import { TransferrableKeys } from '../../transfer/TransferrableKeys';
 
 const test = anyTest as TestInterface<{
@@ -83,4 +84,18 @@ test('appending as many keys as there are TransferrableKeys functions', (t) => {
   t.is(element.ontouchmove, null);
   element.ontouchmove = handler;
   t.is(element.ontouchmove, handler);
+});
+
+test.serial('unsubscription with `null` value does not cause an error', (t) => {
+  const { element } = t.context;
+  const handler = (e: any) => console.log(e);
+
+  t.is(element.onclick, null);
+  element.onclick = handler;
+  t.is(element.onclick, handler);
+  element.dispatchEvent(new Event("click",  {}));
+
+  element.onclick = null;
+  t.is(element.onclick, null);
+  element.dispatchEvent(new Event("click",  {}));
 });

--- a/src/worker-thread/dom/HTMLElement.ts
+++ b/src/worker-thread/dom/HTMLElement.ts
@@ -22,7 +22,9 @@ export const appendGlobalEventProperties = (keys: Array<string>): void => {
         if (stored) {
           this.removeEventListener(normalizedKey, stored);
         }
-        this.addEventListener(normalizedKey, value);
+        if (value instanceof Function) {
+          this.addEventListener(normalizedKey, value);
+        }
         this[TransferrableKeys.propertyEventHandlers][normalizedKey] = value;
       },
     });


### PR DESCRIPTION
Removing of event listener with in a way like: `element.onclick = null;`, stores `null` as a handler.