### PR TITLE
Fix rollup plugin extension

### DIFF
--- a/config/rollup.plugins.mjs
+++ b/config/rollup.plugins.mjs
@@ -93,12 +93,12 @@ export function removeDebugCommandExecutors() {
                 if (property.key.name === 'print') {
                   toDiscover--;
                 } else {
-                  validPropertyRanges.push([property.range[0], property.range[1]]);
+                  validPropertyRanges.push([property.start, property.end]);
                 }
               }
             }
 
-            source.overwrite(node.range[0], node.range[1], outputPropertyRange(code, validPropertyRanges));
+            source.overwrite(node.start, node.end, outputPropertyRange(code, validPropertyRanges));
           }
         },
       });
@@ -124,7 +124,7 @@ export function removeWorkerWhitespace() {
 
       simple(program, {
         TemplateLiteral(node) {
-          let literalValue = code.substring(node.range[0], node.range[1]);
+          let literalValue = code.substring(node.start, node.end);
           literalValue = literalValue
             .replace(/\) \{/g, '){')
             .replace(/, /g, ',')
@@ -132,7 +132,7 @@ export function removeWorkerWhitespace() {
             .replace(/\t/g, '')
             .replace(/[ ]{2,}/g, '')
             .replace(/\n/g, '');
-          source.overwrite(node.range[0], node.range[1], literalValue);
+          source.overwrite(node.start, node.end, literalValue);
         },
       });
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.34.0",
   "description": "A facsimile of a modern DOM implementation intended to run in a Web Worker.",
   "main": "dist/main",
+  "type": "module",
   "files": [
     "dist"
   ],
@@ -109,9 +110,6 @@
     "./dist/amp-production/worker/worker.nodom.mjs": {
       "brotli": "2 kB"
     }
-  },
-  "esm": {
-    "cjs": true
   },
   "ava": {
     "files": [


### PR DESCRIPTION
rollup plugin has updated and uses `start` and `en` instead of `range` now.