### PR TITLE
Sync checked state from main thread to worker

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/src/main-thread/commands/event-subscription.ts
+++ b/src/main-thread/commands/event-subscription.ts
@@ -54,7 +54,7 @@ export const sendValueChangeOnAttributeMutation = (workerContext: WorkerContext,
 };
 
 /**
- * Tell WorkerDOM what the value is for a Node.
+ * Tell WorkerDOM what the value and checked state are for a Node.
  * @param worker whom to dispatch value toward.
  * @param node where to get the value from.
  */
@@ -64,6 +64,7 @@ const fireValueChange = (workerContext: WorkerContext, node: RenderableElement):
     [TransferrableKeys.sync]: {
       [TransferrableKeys.index]: node._index_,
       [TransferrableKeys.value]: node.value,
+      [TransferrableKeys.checked]: node.checked,
     },
   });
 

--- a/src/main-thread/debugging.ts
+++ b/src/main-thread/debugging.ts
@@ -108,6 +108,7 @@ function readableTransferrableSyncValue(nodeContext: NodeContext, value: Transfe
   return {
     target: nodeContext.getNode(index) || index,
     value: value[TransferrableKeys.value],
+    checked: value[TransferrableKeys.checked],
   };
 }
 

--- a/src/test/htmlinputelement/syncValuePropagation.test.ts
+++ b/src/test/htmlinputelement/syncValuePropagation.test.ts
@@ -1,0 +1,78 @@
+import anyTest, { TestFn } from 'ava';
+import { HTMLInputElement } from '../../worker-thread/dom/HTMLInputElement.js';
+import { propagate } from '../../worker-thread/SyncValuePropagation.js';
+import { createTestingDocument } from '../DocumentCreation.js';
+import { TransferrableKeys } from '../../transfer/TransferrableKeys.js';
+import { MessageType } from '../../transfer/Messages.js';
+import { TransferrableSyncValue } from '../../transfer/TransferrableSyncValue.js';
+
+const test = anyTest as TestFn<{
+  element: HTMLInputElement;
+  sendSyncMessage: (sync: TransferrableSyncValue) => void;
+}>;
+
+test.beforeEach((t) => {
+  const document = createTestingDocument();
+  const element = document.createElement('input') as HTMLInputElement;
+
+  let listener: Function = () => {};
+  document.addGlobalEventListener = (_type: string, handler: Function) => {
+    listener = handler;
+  };
+  propagate({ document } as any);
+
+  t.context = {
+    element,
+    sendSyncMessage: (sync) =>
+      listener({
+        data: {
+          [TransferrableKeys.type]: MessageType.SYNC,
+          [TransferrableKeys.sync]: sync,
+        },
+      }),
+  };
+});
+
+test('syncs value from the main thread', (t) => {
+  const { element, sendSyncMessage } = t.context;
+
+  sendSyncMessage({
+    [TransferrableKeys.index]: element[TransferrableKeys.index],
+    [TransferrableKeys.value]: 'abc',
+  });
+
+  t.is(element.value, 'abc');
+});
+
+test('syncs checked from the main thread', (t) => {
+  const { element, sendSyncMessage } = t.context;
+
+  sendSyncMessage({
+    [TransferrableKeys.index]: element[TransferrableKeys.index],
+    [TransferrableKeys.value]: 'on',
+    [TransferrableKeys.checked]: true,
+  });
+
+  t.true(element.checked);
+
+  sendSyncMessage({
+    [TransferrableKeys.index]: element[TransferrableKeys.index],
+    [TransferrableKeys.value]: 'on',
+    [TransferrableKeys.checked]: false,
+  });
+
+  t.false(element.checked);
+});
+
+test('leaves checked untouched when the sync has no checked state', (t) => {
+  const { element, sendSyncMessage } = t.context;
+
+  element.checked = true;
+
+  sendSyncMessage({
+    [TransferrableKeys.index]: element[TransferrableKeys.index],
+    [TransferrableKeys.value]: 'on',
+  });
+
+  t.true(element.checked);
+});

--- a/src/transfer/TransferrableSyncValue.ts
+++ b/src/transfer/TransferrableSyncValue.ts
@@ -3,4 +3,5 @@ import { TransferrableKeys } from './TransferrableKeys.js';
 export interface TransferrableSyncValue {
   readonly [TransferrableKeys.index]: number;
   readonly [TransferrableKeys.value]: string | number;
+  readonly [TransferrableKeys.checked]?: boolean;
 }

--- a/src/worker-thread/SyncValuePropagation.ts
+++ b/src/worker-thread/SyncValuePropagation.ts
@@ -24,6 +24,10 @@ export function propagate(global: WorkerDOMGlobalScope): void {
       (node.ownerDocument as Document)[TransferrableKeys.allowTransfer] = false;
       // Modify the private backing ivar of `value` property to avoid mutation/sync cycle.
       node.value = sync[TransferrableKeys.value];
+      const checked = sync[TransferrableKeys.checked];
+      if (checked !== undefined) {
+        node.checked = checked;
+      }
       (node.ownerDocument as Document)[TransferrableKeys.allowTransfer] = true;
     }
   });

--- a/web_compat_table.md
+++ b/web_compat_table.md
@@ -524,7 +524,7 @@ This section highlights the DOM APIs that are implemented in WorkerDOM currently
 | HTMLInputElement.autocomplete                       | ✔️     |                                                  | 
 | HTMLInputElement.autofocus                          | ✔️     |                                                  | 
 | HTMLInputElement.blur()                             | ✔️     |                                                  | 
-| HTMLInputElement.checked                            | ✖️     |                                                  | 
+| HTMLInputElement.checked                            | ✔️     | Radio group siblings are not synced              | 
 | HTMLInputElement.checkValidity()                    | ✖️     |                                                  | 
 | HTMLInputElement.defaultChecked                     | ✔️     |                                                  | 
 | HTMLInputElement.defaultValue                       | ✔️     |                                                  | 


### PR DESCRIPTION
Fixes #751

Setting `checked` from the worker already updates the real DOM via a PROPERTIES mutation, but the reverse was missing: when the user interacts with an input, the main thread only syncs `value` back to the worker, so the worker's `checked` stays permanently stale.

This adds an optional `checked` field to the existing SYNC message: `fireValueChange` includes it alongside `value`, and the worker applies it inside the same `allowTransfer` window that already prevents a mutation echo for `value`. The field is optional so older main-thread bundles remain compatible.

Verified end to end in chromium with a checkbox demo: before, clicking the real checkbox left the worker seeing `checked === false`; after, both directions stay in sync.

Known limitations, unchanged by this PR:
- Radio group siblings: clicking radio A fires events only on A, so a sibling radio that the browser unchecks silently is not synced. worker-dom currently has no radio group logic on the worker side either (setting `checked = true` on a radio in the worker does not uncheck its siblings there), so this is a pre-existing gap rather than a partial fix.
- Initial state: an `<input checked>` present at hydration is still not reflected into the `checked` property; sync only fires on events and attribute mutations.

Also updates the SYNC debug formatter and marks `HTMLInputElement.checked` as supported in web_compat_table.md with a note about radio groups.

---

CI note: the first run failed in the lint job before any of this PR's code was linted. There is no lockfile, so `yarn install` freshly resolves `cbor@10` (via ava), which requires Node.js >= 20, and the lint workflow was the only one still on Node.js 18 (EOL). The second commit bumps that workflow to 22, matching the test and size workflows. The same failure reproduces on a clean checkout of `main` with Node.js 18.
